### PR TITLE
fix(useMultiComboboxState): optional chain member access on the collection

### DIFF
--- a/.changeset/funny-rockets-fry.md
+++ b/.changeset/funny-rockets-fry.md
@@ -1,0 +1,5 @@
+---
+'@project44-manifest/react': patch
+---
+
+[useMultiComboboxState] optional change property access on collection interface

--- a/packages/react/src/state/useMultiComboboxState.ts
+++ b/packages/react/src/state/useMultiComboboxState.ts
@@ -141,7 +141,7 @@ export function useMultiComboboxState<T extends object>(
 			onSelectionChange?.(selectedKeys);
 
 			// Stop menu from reopening from useEffect
-			const itemText = collection.getItem(selectionManager.focusedKey).textValue ?? '';
+			const itemText = collection.getItem(selectionManager.focusedKey)?.textValue ?? '';
 
 			valueRef.current = itemText;
 		}


### PR DESCRIPTION
<!--- We really appreciated your pull request! -->

DES-394

## 📝 Description

`getItem` on a react-aria collection does not always return an item, optional chaining to prevent errors from being thrown.

## Screenshots

> Please provide screenshots for any visual changes

## Merge checklist

- [ ] Added/updated tests
- [ ] Added changeset
