### PR TITLE
fix: remove usage of the Object.hasOwn method

### DIFF
--- a/.changeset/tidy-bananas-listen.md
+++ b/.changeset/tidy-bananas-listen.md
@@ -1,0 +1,6 @@
+---
+'eslint-config-manifest': patch
+'@project44-manifest/react-utils': patch
+---
+
+Removing usage of Object.hasOwn method to support lesser node versions

--- a/packages/eslint-config/rules/best-practices.js
+++ b/packages/eslint-config/rules/best-practices.js
@@ -32,8 +32,6 @@ module.exports = {
     ],
     // Prefer compact syntax when applicable.
     'prefer-exponentiation-operator': 'error',
-    // Prefer use of Object.hasOwn() over Object.prototype.hasOwnProperty.call().
-    'prefer-object-has-own': 'error',
     // Prefer compact syntax when applicable
     'prefer-regex-literals': ['error', { disallowRedundantWrapping: true }],
     // Disallow assignments that can lead to race conditions due to usage of await or yield.

--- a/packages/react-utils/src/filterDOMProps.ts
+++ b/packages/react-utils/src/filterDOMProps.ts
@@ -255,7 +255,7 @@ export function filterDOMProps<T extends Record<string, unknown>>(
   const result: Record<string, unknown> = {};
 
   for (const prop in props) {
-    if (Object.hasOwn(props, prop)) {
+    if (Object.prototype.hasOwnProperty.call(props, prop)) {
       const isAllowed =
         domProps.has(prop) ||
         ariaRegex.test(prop) ||

--- a/packages/react-utils/src/mergeProps.ts
+++ b/packages/react-utils/src/mergeProps.ts
@@ -16,7 +16,7 @@ export function mergeProps<T extends Props[]>(...args: T): UnionToIntersection<T
     const props: Record<string, unknown> = args[i];
 
     for (const prop in props) {
-      if (Object.hasOwn(props, prop)) {
+      if (Object.prototype.hasOwnProperty.call(props, prop)) {
         const mergedValue = result[prop];
         const propValue = props[prop];
 


### PR DESCRIPTION
<!--- We really appreciated your pull request! -->

Closes # <!-- Github issue # here -->

## 📝 Description

Not all of our products are on node versions that support the `hasOwn` method, need to remove usage of this method for the time being

## Screenshots

> Please provide screenshots for any visual changes

## Merge checklist

- [ ] Added/updated tests
- [ ] Added changeset
