### PR TITLE
feat: add breadcrumb

### DIFF
--- a/.changeset/rotten-otters-kiss.md
+++ b/.changeset/rotten-otters-kiss.md
@@ -1,0 +1,9 @@
+---
+'@project44-manifest/react-breadcrumb': minor
+'@project44-manifest/react-avatar': minor
+'@project44-manifest/react': minor
+'@project44-manifest/react-icon': minor
+'@project44-manifest/react-link': minor
+---
+
+added breadcrumb components

--- a/packages/react/components/breadcrumb/LICENSE
+++ b/packages/react/components/breadcrumb/LICENSE
@@ -1,0 +1,18 @@
+MIT License
+
+Copyright (c) 2021 project44, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/react/components/breadcrumb/README.md
+++ b/packages/react/components/breadcrumb/README.md
@@ -1,0 +1,4 @@
+# @project44-manifest/react-breadcrumb
+
+This package is part of [Manifest Design System](https://github.com/project44/manifest). Please see
+the repo for more details.

--- a/packages/react/components/breadcrumb/jest.config.js
+++ b/packages/react/components/breadcrumb/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  preset: 'jest-preset-manifest',
+};

--- a/packages/react/components/breadcrumb/moon.yml
+++ b/packages/react/components/breadcrumb/moon.yml
@@ -1,0 +1,27 @@
+type: 'library'
+language: 'typescript'
+
+workspace:
+  inheritedTasks:
+    rename:
+      buildPackage: 'build'
+
+tasks:
+  build:
+    outputs:
+      - 'esm'
+      - 'lib'
+
+dependsOn:
+  - id: 'icon'
+    scope: 'production'
+  - id: 'icons'
+    scope: 'production'
+  - id: 'link'
+    scope: 'production'
+  - id: 'styles'
+    scope: 'production'
+  - id: 'types'
+    scope: 'development'
+  - id: 'utils'
+    scope: 'production'

--- a/packages/react/components/breadcrumb/package.json
+++ b/packages/react/components/breadcrumb/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@project44-manifest/react-breadcrumb",
+  "version": "0.0.0",
+  "description": "site navigation breadcrumb links",
+  "license": "MIT",
+  "author": "project44",
+  "keywords": [
+    "manifest",
+    "design",
+    "system",
+    "react",
+    "components"
+  ],
+  "sideEffects": false,
+  "main": "./lib/index.js",
+  "module": "./esm/index.js",
+  "types": "./dts/index.d.ts",
+  "files": [
+    "dts/**/*.d.ts",
+    "esm/**/*.{js,map}",
+    "lib/**/*.{js,map}",
+    "src/**/*.{ts,tsx,json}"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:project-44/manifest.git",
+    "directory": "packages/breadcrumb"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "peerDependencies": {
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
+  },
+  "dependencies": {
+    "@project44-manifest/react-icon": "^0.1.0",
+    "@project44-manifest/react-icons": "^0.1.0",
+    "@project44-manifest/react-link": "^0.0.0",
+    "@project44-manifest/react-styles": "^1.0.1",
+    "@project44-manifest/react-utils": "^0.2.3"
+  },
+  "devDependencies": {
+    "@project44-manifest/react-types": "^0.2.1",
+    "react": "^18.1.0",
+    "react-dom": "^18.1.0"
+  },
+  "packemon": {
+    "platform": "browser"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dts/index.d.ts",
+      "browser": {
+        "module": "./esm/index.js",
+        "import": "./esm/index.js",
+        "default": "./lib/index.js"
+      },
+      "default": "./lib/index.js"
+    }
+  }
+}

--- a/packages/react/components/breadcrumb/src/Breadcrumb.styles.ts
+++ b/packages/react/components/breadcrumb/src/Breadcrumb.styles.ts
@@ -1,0 +1,12 @@
+import { styled } from '@project44-manifest/react-styles';
+
+export const StyledBreadcrumb = styled('nav', {
+  overflowX: 'auto',
+});
+
+export const StyledBreadcrumbList = styled('ol', {
+  d: 'flex',
+  listStyle: 'none',
+  margin: 0,
+  p: 0,
+});

--- a/packages/react/components/breadcrumb/src/Breadcrumb.tsx
+++ b/packages/react/components/breadcrumb/src/Breadcrumb.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { cx } from '@project44-manifest/react-styles';
+import type { ForwardRefComponent } from '@project44-manifest/react-types';
+import { StyledBreadcrumb, StyledBreadcrumbList } from './Breadcrumb.styles';
+import type { BreadcrumbElement, BreadcrumbProps } from './Breadcrumb.types';
+
+export const Breadcrumb = React.forwardRef((props, forwardedRef) => {
+  const { as, children, className: classNameProp, css, ...other } = props;
+
+  const className = cx('manifest-breadcrumb', classNameProp);
+
+  return (
+    <StyledBreadcrumb
+      {...other}
+      ref={forwardedRef}
+      aria-label="Breadcrumb"
+      as={as}
+      className={className}
+      css={css}
+    >
+      <StyledBreadcrumbList className="manifest-breadcrumb__list">{children}</StyledBreadcrumbList>
+    </StyledBreadcrumb>
+  );
+}) as ForwardRefComponent<BreadcrumbElement, BreadcrumbProps>;

--- a/packages/react/components/breadcrumb/src/Breadcrumb.types.ts
+++ b/packages/react/components/breadcrumb/src/Breadcrumb.types.ts
@@ -1,0 +1,10 @@
+import type { CSS } from '@project44-manifest/react-styles';
+
+export type BreadcrumbElement = 'nav';
+
+export interface BreadcrumbProps {
+  /**
+   * Theme aware style object
+   */
+  css?: CSS;
+}

--- a/packages/react/components/breadcrumb/src/BreadcrumbItem.styles.ts
+++ b/packages/react/components/breadcrumb/src/BreadcrumbItem.styles.ts
@@ -1,0 +1,19 @@
+import { Icon } from '@project44-manifest/react-icon';
+import { Link } from '@project44-manifest/react-link';
+import { styled } from '@project44-manifest/react-styles';
+
+export const StyledBreadcrumbItem = styled('li', {
+  d: 'flex',
+  alignItems: 'center',
+  color: '$text-secondary',
+
+  [`& ${Link}`]: {
+    typography: '$subtext',
+    color: 'inherit',
+    textDecoration: 'none',
+  },
+
+  [`&:last-child ${Icon}`]: {
+    display: 'none',
+  },
+});

--- a/packages/react/components/breadcrumb/src/BreadcrumbItem.tsx
+++ b/packages/react/components/breadcrumb/src/BreadcrumbItem.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { ChevronRight } from '@project44-manifest/react-icons';
+import { Link } from '@project44-manifest/react-link';
+import { cx } from '@project44-manifest/react-styles';
+import type { ForwardRefComponent } from '@project44-manifest/react-types';
+import { StyledBreadcrumbItem } from './BreadcrumbItem.styles';
+import type { BreadcrumbItemElement, BreadcrumbItemProps } from './BreadcrumbItem.types';
+
+export const BreadcrumbItem = React.forwardRef((props, forwardedRef) => {
+  const { as, children, className: classNameProp, css, href, ...other } = props;
+
+  const className = cx('manifest-breadcrumb-item', classNameProp);
+
+  return (
+    <StyledBreadcrumbItem {...other} ref={forwardedRef} as={as} className={className} css={css}>
+      <Link href={href}>{children}</Link>
+      <ChevronRight aria-hidden className="manifest-breadcrumb-item__icon" size="small" />
+    </StyledBreadcrumbItem>
+  );
+}) as ForwardRefComponent<BreadcrumbItemElement, BreadcrumbItemProps>;

--- a/packages/react/components/breadcrumb/src/BreadcrumbItem.types.ts
+++ b/packages/react/components/breadcrumb/src/BreadcrumbItem.types.ts
@@ -1,0 +1,15 @@
+import type { CSS } from '@project44-manifest/react-styles';
+
+export type BreadcrumbItemElement = 'li';
+
+export interface BreadcrumbItemProps {
+  /**
+   * Theme aware style object
+   */
+  css?: CSS;
+
+  /**
+   * Breadcrumb item link href
+   */
+  href: string;
+}

--- a/packages/react/components/breadcrumb/src/index.ts
+++ b/packages/react/components/breadcrumb/src/index.ts
@@ -1,0 +1,4 @@
+export * from './Breadcrumb';
+export * from './Breadcrumb.types';
+export * from './BreadcrumbItem';
+export * from './BreadcrumbItem.types';

--- a/packages/react/components/breadcrumb/stories/Breadcrumb.stories.tsx
+++ b/packages/react/components/breadcrumb/stories/Breadcrumb.stories.tsx
@@ -1,0 +1,26 @@
+import { Breadcrumb, BreadcrumbItem } from '../src';
+
+export default {
+  title: 'Components/Breadcrumb',
+  component: Breadcrumb,
+};
+
+export const Default = () => (
+  <Breadcrumb>
+    <BreadcrumbItem href="#home">Home</BreadcrumbItem>
+    <BreadcrumbItem href="#catalog">Catalog</BreadcrumbItem>
+    <BreadcrumbItem href="#products">Products</BreadcrumbItem>
+  </Breadcrumb>
+);
+
+export const Collapsed = () => (
+  <Breadcrumb>
+    <BreadcrumbItem href="#home">Home</BreadcrumbItem>
+    <BreadcrumbItem href="#catalog">Catalog</BreadcrumbItem>
+    <BreadcrumbItem href="#product">Product</BreadcrumbItem>
+    <BreadcrumbItem href="#variants">Variants</BreadcrumbItem>
+    <BreadcrumbItem href="#variant">Variant</BreadcrumbItem>
+    <BreadcrumbItem href="#customizations">Customizations</BreadcrumbItem>
+    <BreadcrumbItem href="#sizes">Sizes</BreadcrumbItem>
+  </Breadcrumb>
+);

--- a/packages/react/components/breadcrumb/tests/Breadcrumb.test.tsx
+++ b/packages/react/components/breadcrumb/tests/Breadcrumb.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import { Breadcrumb, BreadcrumbItem } from '../src';
+
+describe('breadcrumb', () => {
+  it('should render crumb links', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbItem href="#home">Home</BreadcrumbItem>
+        <BreadcrumbItem href="#catalog">Catalog</BreadcrumbItem>
+        <BreadcrumbItem href="#products">Products</BreadcrumbItem>
+      </Breadcrumb>,
+    );
+
+    expect(screen.getByText('Home')).toBeDefined();
+    expect(screen.getByText('Catalog')).toBeDefined();
+    expect(screen.getByText('Products')).toBeDefined();
+
+    const anchors = screen.getAllByRole('link');
+    expect(anchors).toHaveLength(3);
+  });
+});

--- a/packages/react/components/breadcrumb/tsconfig.build.json
+++ b/packages/react/components/breadcrumb/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../../tsconfig.options.json",
+  "compilerOptions": {
+    "outDir": "dts",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "references": []
+}

--- a/packages/react/components/breadcrumb/tsconfig.json
+++ b/packages/react/components/breadcrumb/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "extends": "../../../../tsconfig.options.json",
+  "compilerOptions": {
+    "outDir": "../../../../.moon/cache/types/packages/react/components/breadcrumb"
+  },
+  "include": [
+    "src/**/*",
+    "stories/**/*",
+    "tests/**/*"
+  ],
+  "references": [
+    {
+      "path": "../../icons"
+    },
+    {
+      "path": "../../styles"
+    },
+    {
+      "path": "../../types"
+    },
+    {
+      "path": "../../utils"
+    },
+    {
+      "path": "../icon"
+    },
+    {
+      "path": "../link"
+    },
+    {
+      "path": "./tsconfig.build.json"
+    }
+  ]
+}

--- a/packages/react/components/icon/src/Icon.tsx
+++ b/packages/react/components/icon/src/Icon.tsx
@@ -42,3 +42,5 @@ export const Icon = React.forwardRef((props, forwardedRef) => {
     />
   );
 }) as ForwardRefComponent<IconElement, IconProps>;
+
+Icon.toString = () => '.manifest-icon';

--- a/packages/react/components/link/src/Link.tsx
+++ b/packages/react/components/link/src/Link.tsx
@@ -15,3 +15,5 @@ export const Link = React.forwardRef((props, forwardedRef) => {
     </StyledLink>
   );
 }) as ForwardRefComponent<LinkElement, LinkProps>;
+
+Link.toString = () => '.manifest-link';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,9 @@
       "path": "packages/react/components/button"
     },
     {
+      "path": "packages/react/components/breadcrumb"
+    },
+    {
       "path": "packages/react/components/css-baseline"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3237,6 +3237,24 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@project44-manifest/react-breadcrumb@workspace:packages/react/components/breadcrumb":
+  version: 0.0.0-use.local
+  resolution: "@project44-manifest/react-breadcrumb@workspace:packages/react/components/breadcrumb"
+  dependencies:
+    "@project44-manifest/react-icon": ^0.1.0
+    "@project44-manifest/react-icons": ^0.1.0
+    "@project44-manifest/react-link": ^0.0.0
+    "@project44-manifest/react-styles": ^1.0.1
+    "@project44-manifest/react-types": ^0.2.1
+    "@project44-manifest/react-utils": ^0.2.3
+    react: ^18.1.0
+    react-dom: ^18.1.0
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+  languageName: unknown
+  linkType: soft
+
 "@project44-manifest/react-button@^1.0.2, @project44-manifest/react-button@workspace:packages/react/components/button":
   version: 0.0.0-use.local
   resolution: "@project44-manifest/react-button@workspace:packages/react/components/button"


### PR DESCRIPTION
<!--- We really appreciated your pull request! -->

Progresses https://github.com/project44/manifest/issues/219

## 📝 Description

- Add new breadcrumb component that accepts a list of children items 
  - _Note_: Responsive design for this PR entails horizontal scroll in the edge case where the crumbs are wider than their bounding container, and a follow-up PR will add further features including truncation and dropdown menu for the hidden crumbs as [discussed here](https://danielroberts-gnf1833.slack.com/archives/C04MX0CVBS4/p1675361789778889?thread_ts=1675355461.723339&cid=C04MX0CVBS4)

https://www.figma.com/file/2vyIjgJEhVc1spMWwkgzQ5/branch/5eZBJBY22T0H48kepdRpFl/Manifest-Design-System?node-id=8386:4893&t=z4z6jNVEc6l4iafm-0

## Screenshots

<img width="233" alt="image" src="https://user-images.githubusercontent.com/3459902/216470762-21f0baba-74e9-42e9-890c-37f181575f46.png">


## Merge checklist

- [x] Added/updated tests
- [x] Added changeset
