### PR TITLE
refactor: Card styles to shared style

### DIFF
--- a/.changeset/short-papayas-hide.md
+++ b/.changeset/short-papayas-hide.md
@@ -1,0 +1,7 @@
+---
+'@project44-manifest/react-card': minor
+'@project44-manifest/react': minor
+'@project44-manifest/react-styles': minor
+---
+
+refactored card styles to shared styles

--- a/packages/react/components/card/src/Card.styles.ts
+++ b/packages/react/components/card/src/Card.styles.ts
@@ -1,9 +1,3 @@
-import { styled } from '@project44-manifest/react-styles';
+import { card, styled } from '@project44-manifest/react-styles';
 
-export const StyledCard = styled('div', {
-  backgroundColor: '$background-surface',
-  borderRadius: '$small',
-  boxShadow: '$medium',
-  boxSizing: 'border-box',
-  overflow: 'hidden',
-});
+export const StyledCard = styled('div', card);

--- a/packages/react/styles/src/styles/shared/card.ts
+++ b/packages/react/styles/src/styles/shared/card.ts
@@ -1,0 +1,9 @@
+import { css } from '../../stitches';
+
+export const card = css({
+  backgroundColor: '$background-surface',
+  borderRadius: '$small',
+  boxShadow: '$medium',
+  boxSizing: 'border-box',
+  overflow: 'hidden',
+});

--- a/packages/react/styles/src/styles/shared/index.ts
+++ b/packages/react/styles/src/styles/shared/index.ts
@@ -1,1 +1,2 @@
+export * from './card';
 export * from './focus';


### PR DESCRIPTION
<!--- We really appreciated your pull request! -->


## 📝 Description

- Refactor `Card` style to `styles` package, in preparation for re-use in `ActionCard`

## Screenshots

<img width="617" alt="image" src="https://user-images.githubusercontent.com/3459902/218833877-5d00b607-7b19-407b-ba72-5ca88a70732c.png">


## Merge checklist

- [ ] Added/updated tests
- [x] Added changeset
