### PR TITLE
feat: add action card

### DIFF
--- a/.changeset/giant-dogs-dress.md
+++ b/.changeset/giant-dogs-dress.md
@@ -1,0 +1,10 @@
+---
+'@project44-manifest/react-action-card': minor
+'@project44-manifest/react-card': minor
+'@project44-manifest/react-provider': minor
+'@project44-manifest/react-transition': minor
+'@project44-manifest/react': minor
+'@project44-manifest/react-styles': minor
+---
+
+added action card

--- a/packages/react/components/action-card/LICENSE
+++ b/packages/react/components/action-card/LICENSE
@@ -1,0 +1,18 @@
+MIT License
+
+Copyright (c) 2021 project44, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/react/components/action-card/README.md
+++ b/packages/react/components/action-card/README.md
@@ -1,0 +1,4 @@
+# @project44-manifest/react-action-card
+
+This package is part of [Manifest Design System](https://github.com/project44/manifest). Please see
+the repo for more details.

--- a/packages/react/components/action-card/jest.config.js
+++ b/packages/react/components/action-card/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  preset: 'jest-preset-manifest',
+};

--- a/packages/react/components/action-card/moon.yml
+++ b/packages/react/components/action-card/moon.yml
@@ -1,0 +1,23 @@
+type: 'library'
+language: 'typescript'
+
+workspace:
+  inheritedTasks:
+    rename:
+      buildPackage: 'build'
+
+tasks:
+  build:
+    outputs:
+      - 'esm'
+      - 'lib'
+
+dependsOn:
+  - id: 'icons'
+    scope: 'production'
+  - id: 'styles'
+    scope: 'production'
+  - id: 'types'
+    scope: 'development'
+  - id: 'utils'
+    scope: 'production'

--- a/packages/react/components/action-card/package.json
+++ b/packages/react/components/action-card/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@project44-manifest/react-action-card",
+  "version": "0.0.0",
+  "description": "card with call to action",
+  "license": "MIT",
+  "author": "project44",
+  "keywords": [
+    "manifest",
+    "design",
+    "system",
+    "react",
+    "components"
+  ],
+  "sideEffects": false,
+  "main": "./lib/index.js",
+  "module": "./esm/index.js",
+  "types": "./dts/index.d.ts",
+  "files": [
+    "dts/**/*.d.ts",
+    "esm/**/*.{js,map}",
+    "lib/**/*.{js,map}",
+    "src/**/*.{ts,tsx,json}"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:project-44/manifest.git",
+    "directory": "packages/action-card"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "peerDependencies": {
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
+  },
+  "dependencies": {
+    "@project44-manifest/react-icons": "^0.1.1",
+    "@project44-manifest/react-styles": "^1.0.1",
+    "@project44-manifest/react-utils": "^0.2.3"
+  },
+  "devDependencies": {
+    "@project44-manifest/react-types": "^0.2.1",
+    "react": "^18.1.0",
+    "react-dom": "^18.1.0"
+  },
+  "packemon": {
+    "platform": "browser"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dts/index.d.ts",
+      "browser": {
+        "module": "./esm/index.js",
+        "import": "./esm/index.js",
+        "default": "./lib/index.js"
+      },
+      "default": "./lib/index.js"
+    }
+  }
+}

--- a/packages/react/components/action-card/src/ActionCard.styles.ts
+++ b/packages/react/components/action-card/src/ActionCard.styles.ts
@@ -1,0 +1,7 @@
+import { card, styled } from '@project44-manifest/react-styles';
+
+export const StyledActionCard = styled('a', card, {
+  display: 'inline-block',
+  color: '$text-primary',
+  textDecoration: 'none',
+});

--- a/packages/react/components/action-card/src/ActionCard.tsx
+++ b/packages/react/components/action-card/src/ActionCard.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { cx } from '@project44-manifest/react-styles';
+import type { ForwardRefComponent } from '@project44-manifest/react-types';
+import { StyledActionCard } from './ActionCard.styles';
+import type { ActionCardElement, ActionCardProps } from './ActionCard.types';
+
+export const ActionCard = React.forwardRef((props, forwardedRef) => {
+  const { as, children, className: classNameProp, href, css, ...other } = props;
+
+  const className = cx('manifest-action-card', classNameProp);
+
+  return (
+    <StyledActionCard
+      {...other}
+      ref={forwardedRef}
+      as={as}
+      className={className}
+      css={css}
+      href={href}
+    >
+      {children}
+    </StyledActionCard>
+  );
+}) as ForwardRefComponent<ActionCardElement, ActionCardProps>;

--- a/packages/react/components/action-card/src/ActionCard.types.ts
+++ b/packages/react/components/action-card/src/ActionCard.types.ts
@@ -1,0 +1,15 @@
+import type { CSS } from '@project44-manifest/react-styles';
+
+export type ActionCardElement = 'a';
+
+export interface ActionCardProps {
+  /**
+   * Theme aware style object
+   */
+  css?: CSS;
+
+  /**
+   * The href link to navigate to when the card is clicked
+   */
+  href: string;
+}

--- a/packages/react/components/action-card/src/ActionCardBody/ActionCardBody.styles.ts
+++ b/packages/react/components/action-card/src/ActionCardBody/ActionCardBody.styles.ts
@@ -1,0 +1,8 @@
+import { styled } from '@project44-manifest/react-styles';
+
+export const StyledActionCardBody = styled('div', {
+  px: '$large',
+  paddingBottom: '$large',
+  typography: '$body',
+  width: '100%',
+});

--- a/packages/react/components/action-card/src/ActionCardBody/ActionCardBody.tsx
+++ b/packages/react/components/action-card/src/ActionCardBody/ActionCardBody.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { cx } from '@project44-manifest/react-styles';
+import type { ForwardRefComponent } from '@project44-manifest/react-types';
+import { StyledActionCardBody } from './ActionCardBody.styles';
+import type { ActionCardBodyElement, ActionCardBodyProps } from './ActionCardBody.types';
+
+export const ActionCardBody = React.forwardRef((props, forwardedRef) => {
+  const { as, children, className: classNameProp, css, ...other } = props;
+
+  const className = cx('manifest-action-card-body', classNameProp);
+
+  return (
+    <StyledActionCardBody {...other} ref={forwardedRef} as={as} className={className} css={css}>
+      {children}
+    </StyledActionCardBody>
+  );
+}) as ForwardRefComponent<ActionCardBodyElement, ActionCardBodyProps>;

--- a/packages/react/components/action-card/src/ActionCardBody/ActionCardBody.types.ts
+++ b/packages/react/components/action-card/src/ActionCardBody/ActionCardBody.types.ts
@@ -1,0 +1,10 @@
+import type { CSS } from '@project44-manifest/react-styles';
+
+export type ActionCardBodyElement = 'div';
+
+export interface ActionCardBodyProps {
+  /**
+   * Theme aware style object
+   */
+  css?: CSS;
+}

--- a/packages/react/components/action-card/src/ActionCardBody/index.ts
+++ b/packages/react/components/action-card/src/ActionCardBody/index.ts
@@ -1,0 +1,2 @@
+export * from './ActionCardBody';
+export * from './ActionCardBody.types';

--- a/packages/react/components/action-card/src/ActionCardHeader/ActionCardHeader.styles.ts
+++ b/packages/react/components/action-card/src/ActionCardHeader/ActionCardHeader.styles.ts
@@ -1,0 +1,10 @@
+import { styled } from '@project44-manifest/react-styles';
+
+export const StyledActionCardHeader = styled('div', {
+  alignItems: 'center',
+  display: 'flex',
+  justifyContent: 'space-between',
+  width: '100%',
+  p: '$large',
+  typography: '$title',
+});

--- a/packages/react/components/action-card/src/ActionCardHeader/ActionCardHeader.tsx
+++ b/packages/react/components/action-card/src/ActionCardHeader/ActionCardHeader.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { ArrowRight } from '@project44-manifest/react-icons';
+import { cx } from '@project44-manifest/react-styles';
+import type { ForwardRefComponent } from '@project44-manifest/react-types';
+import { StyledActionCardHeader } from './ActionCardHeader.styles';
+import type { ActionCardHeaderElement, ActionCardHeaderProps } from './ActionCardHeader.types';
+
+export const ActionCardHeader = React.forwardRef((props, forwardedRef) => {
+  const { as, children, className: classNameProp, css, ...other } = props;
+
+  const className = cx('manifest-action-card-header', classNameProp);
+
+  return (
+    <StyledActionCardHeader {...other} ref={forwardedRef} as={as} className={className} css={css}>
+      {children}
+      <ArrowRight aria-hidden className="manifest-action-card-header__icon" />
+    </StyledActionCardHeader>
+  );
+}) as ForwardRefComponent<ActionCardHeaderElement, ActionCardHeaderProps>;

--- a/packages/react/components/action-card/src/ActionCardHeader/ActionCardHeader.types.ts
+++ b/packages/react/components/action-card/src/ActionCardHeader/ActionCardHeader.types.ts
@@ -1,0 +1,10 @@
+import type { CSS } from '@project44-manifest/react-styles';
+
+export type ActionCardHeaderElement = 'div';
+
+export interface ActionCardHeaderProps {
+  /**
+   * Theme aware style object
+   */
+  css?: CSS;
+}

--- a/packages/react/components/action-card/src/ActionCardHeader/index.ts
+++ b/packages/react/components/action-card/src/ActionCardHeader/index.ts
@@ -1,0 +1,2 @@
+export * from './ActionCardHeader';
+export * from './ActionCardHeader.types';

--- a/packages/react/components/action-card/src/ActionCardImage/ActionCardImage.styles.ts
+++ b/packages/react/components/action-card/src/ActionCardImage/ActionCardImage.styles.ts
@@ -1,0 +1,26 @@
+import { pxToRem, styled } from '@project44-manifest/react-styles';
+
+export const StyledActionCardImage = styled('div', {
+  display: 'block',
+  backgroundSize: 'cover',
+  backgroundRepeat: 'no-repeat',
+  backgroundPosition: 'center',
+  objectFit: 'cover',
+
+  variants: {
+    size: {
+      large: {
+        height: pxToRem(180),
+        minWidth: pxToRem(352),
+      },
+      small: {
+        height: pxToRem(130),
+        minWidth: pxToRem(320),
+      },
+    },
+  },
+
+  defaultVariants: {
+    size: 'large',
+  },
+});

--- a/packages/react/components/action-card/src/ActionCardImage/ActionCardImage.tsx
+++ b/packages/react/components/action-card/src/ActionCardImage/ActionCardImage.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { cx } from '@project44-manifest/react-styles';
+import type { ForwardRefComponent } from '@project44-manifest/react-types';
+import { StyledActionCardImage } from './ActionCardImage.styles';
+import type { ActionCardImageElement, ActionCardImageProps } from './ActionCardImage.types';
+
+export const ActionCardImage = React.forwardRef((props, forwardedRef) => {
+  const { as, children, className: classNameProp, css, size = 'large', src, ...other } = props;
+
+  const className = cx('manifest-action-card-image', classNameProp, {
+    [`manifest-action-card-image--${size}`]: size,
+  });
+
+  return (
+    <StyledActionCardImage
+      {...other}
+      ref={forwardedRef}
+      as={as}
+      className={className}
+      css={{ ...css, backgroundImage: `url(${src})` }}
+      size={size}
+    />
+  );
+}) as ForwardRefComponent<ActionCardImageElement, ActionCardImageProps>;

--- a/packages/react/components/action-card/src/ActionCardImage/ActionCardImage.types.ts
+++ b/packages/react/components/action-card/src/ActionCardImage/ActionCardImage.types.ts
@@ -1,0 +1,20 @@
+import type { CSS } from '@project44-manifest/react-styles';
+
+export type ActionCardImageElement = 'div';
+
+export interface ActionCardImageProps {
+  /**
+   * Theme aware style object
+   */
+  css?: CSS;
+  /**
+   * The size of the card image
+   *
+   * @default 'large'
+   */
+  size?: 'large' | 'small';
+  /**
+   * The source for the image
+   */
+  src: string;
+}

--- a/packages/react/components/action-card/src/ActionCardImage/index.ts
+++ b/packages/react/components/action-card/src/ActionCardImage/index.ts
@@ -1,0 +1,2 @@
+export * from './ActionCardImage';
+export * from './ActionCardImage.types';

--- a/packages/react/components/action-card/src/index.ts
+++ b/packages/react/components/action-card/src/index.ts
@@ -1,0 +1,5 @@
+export * from './ActionCard';
+export * from './ActionCard.types';
+export * from './ActionCardBody';
+export * from './ActionCardHeader';
+export * from './ActionCardImage';

--- a/packages/react/components/action-card/stories/ActionCard.stories.tsx
+++ b/packages/react/components/action-card/stories/ActionCard.stories.tsx
@@ -1,0 +1,58 @@
+import { Box, Stack } from '@project44-manifest/react-layout';
+import type { StoryFn } from '@storybook/react';
+import { ActionCard, ActionCardBody, ActionCardHeader, ActionCardImage } from '../src';
+
+export default {
+  title: 'Components/ActionCard',
+  component: ActionCard,
+  subcomponents: { ActionCardHeader, ActionCardBody, ActionCardImage },
+  decorators: [
+    (Story: StoryFn) => (
+      <Stack gap="medium" orientation="horizontal">
+        <Story />
+      </Stack>
+    ),
+  ],
+};
+
+export const Size = () => (
+  <>
+    <Box>
+      <ActionCard href="#">
+        <ActionCardImage size="large" src="https://picsum.photos/400/600" />
+        <ActionCardHeader>Title</ActionCardHeader>
+        <ActionCardBody>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+          ut labore et dolore magna aliqua.
+        </ActionCardBody>
+      </ActionCard>
+    </Box>
+    <Box>
+      <ActionCard href="#">
+        <ActionCardImage size="small" src="https://picsum.photos/400/600" />
+        <ActionCardHeader>Title</ActionCardHeader>
+        <ActionCardBody>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+          ut labore et dolore magna aliqua.
+        </ActionCardBody>
+      </ActionCard>
+    </Box>
+  </>
+);
+
+export const WithoutBody = () => (
+  <>
+    <Box>
+      <ActionCard href="#">
+        <ActionCardImage size="large" src="https://picsum.photos/400/600" />
+        <ActionCardHeader>Title</ActionCardHeader>
+      </ActionCard>
+    </Box>
+    <Box>
+      <ActionCard href="#">
+        <ActionCardImage size="small" src="https://picsum.photos/400/600" />
+        <ActionCardHeader>Title</ActionCardHeader>
+      </ActionCard>
+    </Box>
+  </>
+);

--- a/packages/react/components/action-card/tests/ActionCard.test.tsx
+++ b/packages/react/components/action-card/tests/ActionCard.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import { ActionCard, ActionCardBody, ActionCardHeader, ActionCardImage } from '../src';
+
+describe('action-card', () => {
+  it('should render', () => {
+    render(
+      <ActionCard href="#">
+        <ActionCardImage src="https://picsum.photos/400/600" />
+        <ActionCardHeader>Title</ActionCardHeader>
+        <ActionCardBody>Lorem ipsum dolor sit amet</ActionCardBody>
+      </ActionCard>,
+    );
+
+    expect(screen.getByText('Lorem ipsum dolor sit amet')).toBeDefined();
+    expect(screen.getByText('Title')).toBeDefined();
+    expect(screen.getByRole('link')).toHaveAttribute('href', '#');
+  });
+});

--- a/packages/react/components/action-card/tsconfig.build.json
+++ b/packages/react/components/action-card/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../../tsconfig.options.json",
+  "compilerOptions": {
+    "outDir": "dts",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "references": []
+}

--- a/packages/react/components/action-card/tsconfig.json
+++ b/packages/react/components/action-card/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "extends": "../../../../tsconfig.options.json",
+  "compilerOptions": {
+    "outDir": "../../../../.moon/cache/types/packages/react/components/action-card"
+  },
+  "include": [
+    "src/**/*",
+    "stories/**/*",
+    "tests/**/*"
+  ],
+  "references": [
+    {
+      "path": "../../icons"
+    },
+    {
+      "path": "../../styles"
+    },
+    {
+      "path": "../../utils"
+    },
+    {
+      "path": "../card"
+    },
+    {
+      "path": "./tsconfig.build.json"
+    }
+  ]
+}

--- a/packages/react/core/moon.yml
+++ b/packages/react/core/moon.yml
@@ -13,6 +13,7 @@ tasks:
       - 'lib'
 
 dependsOn:
+  - 'action-card'
   - 'avatar'
   - 'button'
   - 'css-baseline'

--- a/packages/react/core/package.json
+++ b/packages/react/core/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@internationalized/date": "^3.0.0",
+    "@project44-manifest/react-action-card": "^0.0.0",
     "@project44-manifest/react-avatar": "^0.2.1",
     "@project44-manifest/react-button": "^1.1.0",
     "@project44-manifest/react-card": "^0.1.0",

--- a/packages/react/core/src/index.ts
+++ b/packages/react/core/src/index.ts
@@ -84,6 +84,7 @@ export type { VisuallyHiddenProps } from './components/VisuallyHidden';
 export { VisuallyHidden } from './components/VisuallyHidden';
 export * from './hooks';
 export * from './state';
+export * from '@project44-manifest/react-action-card';
 export * from '@project44-manifest/react-avatar';
 export * from '@project44-manifest/react-button';
 export * from '@project44-manifest/react-card';

--- a/packages/react/core/tsconfig.json
+++ b/packages/react/core/tsconfig.json
@@ -10,6 +10,9 @@
   ],
   "references": [
     {
+      "path": "../components/action-card"
+    },
+    {
       "path": "../components/avatar"
     },
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,9 @@
       "path": "apps/storybook"
     },
     {
+      "path": "packages/react/components/action-card"
+    },
+    {
       "path": "packages/react/components/avatar"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3206,6 +3206,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@project44-manifest/react-action-card@^0.0.0, @project44-manifest/react-action-card@workspace:packages/react/components/action-card":
+  version: 0.0.0-use.local
+  resolution: "@project44-manifest/react-action-card@workspace:packages/react/components/action-card"
+  dependencies:
+    "@project44-manifest/react-icons": ^0.1.1
+    "@project44-manifest/react-styles": ^1.0.1
+    "@project44-manifest/react-types": ^0.2.1
+    "@project44-manifest/react-utils": ^0.2.3
+    react: ^18.1.0
+    react-dom: ^18.1.0
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+  languageName: unknown
+  linkType: soft
+
 "@project44-manifest/react-avatar@^0.2.1, @project44-manifest/react-avatar@workspace:packages/react/components/avatar":
   version: 0.0.0-use.local
   resolution: "@project44-manifest/react-avatar@workspace:packages/react/components/avatar"
@@ -3605,11 +3621,26 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@project44-manifest/react-utils@npm:^0.2.3":
+  version: 0.2.4
+  resolution: "@project44-manifest/react-utils@npm:0.2.4"
+  dependencies:
+    "@radix-ui/react-slot": ^1.0.1
+    clsx: ^1.1.1
+    lodash.isobject: ^3.0.2
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+  checksum: 2f549f36abcf89291190128d6301f57d733752517afd81f7d5e1985cdcc69fd92af93257af6c6bd44df185ceaa3d7dea3d48403b40844bb3e396ad8e0f4fdd3f
+  languageName: node
+  linkType: hard
+
 "@project44-manifest/react@^2.7.0, @project44-manifest/react@workspace:packages/react/core":
   version: 0.0.0-use.local
   resolution: "@project44-manifest/react@workspace:packages/react/core"
   dependencies:
     "@internationalized/date": ^3.0.0
+    "@project44-manifest/react-action-card": ^0.0.0
     "@project44-manifest/react-avatar": ^0.2.1
     "@project44-manifest/react-button": ^1.1.0
     "@project44-manifest/react-card": ^0.1.0


### PR DESCRIPTION
<!--- We really appreciated your pull request! -->

## 📝 Description

Adds `ActionCard` with full-bleed image. 
Design notes: 
  - Large variant has min-width of 352px and small variant has min-width of 320px

## Screenshots

<img width="787" alt="image" src="https://user-images.githubusercontent.com/3459902/219473615-21d87a75-0f60-45ea-84a8-d7314a8bf59c.png">
<img width="675" alt="image" src="https://user-images.githubusercontent.com/3459902/219473632-d53856c2-f8f9-432a-9fbd-5a23301b232e.png">


## Merge checklist

- [x] Added/updated tests
- [x] Added changeset
