### PR TITLE
feat: update table row classname

### DIFF
--- a/.changeset/flat-starfishes-yell.md
+++ b/.changeset/flat-starfishes-yell.md
@@ -1,0 +1,5 @@
+---
+'@project44-manifest/react-table': major
+---
+
+changed TableRow classname from manifestui-table-row to manifest-table-row to match convention

--- a/packages/react/components/table/src/TableRow/TableRow.tsx
+++ b/packages/react/components/table/src/TableRow/TableRow.tsx
@@ -27,7 +27,7 @@ export const TableRow = React.forwardRef((props, forwardedRef) => {
     setIsHovered(true);
   }, [setIsHovered, showHover]);
 
-  const className = cx('manifestui-table-row', classNameProp);
+  const className = cx('manifest-table-row', classNameProp);
 
   return (
     <StyledTableRow


### PR DESCRIPTION
<!--- We really appreciated your pull request! -->

## 📝 Description

- Updates TableRow component's CSS classname from `manifestui-table-row` to `manifest-table-row` to match codebase convention. 
  - This is a breaking change, reflected by the changeset version bump  

## Screenshots

N/A 

## Merge checklist

- [ ] Added/updated tests
- [x] Added changeset
