### PR TITLE
feat: add loading skeleton

### DIFF
--- a/.changeset/selfish-jars-change.md
+++ b/.changeset/selfish-jars-change.md
@@ -1,0 +1,5 @@
+---
+'@project44-manifest/react-skeleton': minor
+---
+
+added skeleton loading component

--- a/packages/react/components/skeleton/LICENSE
+++ b/packages/react/components/skeleton/LICENSE
@@ -1,0 +1,18 @@
+MIT License
+
+Copyright (c) 2021 project44, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/react/components/skeleton/README.md
+++ b/packages/react/components/skeleton/README.md
@@ -1,0 +1,4 @@
+# @project44-manifest/react-skeleton
+
+This package is part of [Manifest Design System](https://github.com/project44/manifest). Please see
+the repo for more details.

--- a/packages/react/components/skeleton/jest.config.js
+++ b/packages/react/components/skeleton/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  preset: 'jest-preset-manifest',
+};

--- a/packages/react/components/skeleton/moon.yml
+++ b/packages/react/components/skeleton/moon.yml
@@ -1,0 +1,21 @@
+type: 'library'
+language: 'typescript'
+
+workspace:
+  inheritedTasks:
+    rename:
+      buildPackage: 'build'
+
+tasks:
+  build:
+    outputs:
+      - 'esm'
+      - 'lib'
+
+dependsOn:
+  - id: 'styles'
+    scope: 'production'
+  - id: 'types'
+    scope: 'development'
+  - id: 'utils'
+    scope: 'production'

--- a/packages/react/components/skeleton/package.json
+++ b/packages/react/components/skeleton/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@project44-manifest/react-skeleton",
+  "version": "0.0.0",
+  "description": "loading skeleton component",
+  "license": "MIT",
+  "author": "project44",
+  "keywords": [
+    "manifest",
+    "design",
+    "system",
+    "react",
+    "components"
+  ],
+  "sideEffects": false,
+  "main": "./lib/index.js",
+  "module": "./esm/index.js",
+  "types": "./dts/index.d.ts",
+  "files": [
+    "dts/**/*.d.ts",
+    "esm/**/*.{js,map}",
+    "lib/**/*.{js,map}",
+    "src/**/*.{ts,tsx,json}"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:project-44/manifest.git",
+    "directory": "packages/skeleton"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "peerDependencies": {
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
+  },
+  "dependencies": {
+    "@project44-manifest/react-styles": "^1.0.1",
+    "@project44-manifest/react-utils": "^0.2.3",
+    "react-content-loader": "^6.2.0"
+  },
+  "devDependencies": {
+    "@project44-manifest/react-types": "^0.2.1",
+    "react": "^18.1.0",
+    "react-dom": "^18.1.0"
+  },
+  "packemon": {
+    "platform": "browser"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dts/index.d.ts",
+      "browser": {
+        "module": "./esm/index.js",
+        "import": "./esm/index.js",
+        "default": "./lib/index.js"
+      },
+      "default": "./lib/index.js"
+    }
+  }
+}

--- a/packages/react/components/skeleton/src/Skeleton.styles.ts
+++ b/packages/react/components/skeleton/src/Skeleton.styles.ts
@@ -1,0 +1,4 @@
+import ContentLoader from 'react-content-loader';
+import { styled } from '@project44-manifest/react-styles';
+
+export const StyledSkeleton = styled(ContentLoader);

--- a/packages/react/components/skeleton/src/Skeleton.tsx
+++ b/packages/react/components/skeleton/src/Skeleton.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { cx } from '@project44-manifest/react-styles';
+import { StyledSkeleton } from './Skeleton.styles';
+import type { SkeletonProps } from './Skeleton.types';
+
+export function Skeleton(props: SkeletonProps) {
+  const { children, className: classNameProp, css, ...other } = props;
+
+  const id = React.useId();
+
+  const className = cx('manifest-skeleton', classNameProp);
+
+  return (
+    <StyledSkeleton
+      {...other}
+      className={className}
+      css={css}
+      uniqueKey={id} // needed for SSR: https://github.com/danilowoz/react-content-loader#sedrver-side-rendering-ssr---match-snapshot
+    >
+      {children}
+    </StyledSkeleton>
+  );
+}

--- a/packages/react/components/skeleton/src/Skeleton.types.ts
+++ b/packages/react/components/skeleton/src/Skeleton.types.ts
@@ -1,0 +1,15 @@
+import { IContentLoaderProps } from 'react-content-loader';
+import type { CSS } from '@project44-manifest/react-styles';
+
+export const SkeletonElement = 'svg';
+
+export interface SkeletonProps extends IContentLoaderProps {
+  /**
+   * Classes to be applied to the root element
+   */
+  className?: string;
+  /**
+   * Theme aware style object
+   */
+  css?: CSS;
+}

--- a/packages/react/components/skeleton/src/index.ts
+++ b/packages/react/components/skeleton/src/index.ts
@@ -1,0 +1,2 @@
+export { Skeleton } from './Skeleton';
+export type { SkeletonElement, SkeletonProps } from './Skeleton.types';

--- a/packages/react/components/skeleton/stories/Skeleton.stories.tsx
+++ b/packages/react/components/skeleton/stories/Skeleton.stories.tsx
@@ -1,0 +1,86 @@
+import { Grid, GridItem } from '@project44-manifest/react-layout';
+import { Skeleton } from '../src';
+
+export default {
+  title: 'Components/Skeleton',
+  component: Skeleton,
+};
+
+export const Card = () => (
+  <Grid columns="repeat(3, 1fr)" css={{ width: '100%' }} gap="large">
+    <GridItem>
+      <Skeleton height={334} width="100%">
+        <rect height="180" rx="4" ry="4" width="100%" x="0" y="0" />
+        <rect height="15" rx="0" ry="0" width="90%" x="0" y="200" />
+        <rect height="15" rx="0" ry="0" width="90%" x="0" y="225" />
+      </Skeleton>
+    </GridItem>
+    <GridItem>
+      <Skeleton height={334} width="100%">
+        <rect height="180" rx="4" ry="4" width="100%" x="0" y="0" />
+        <rect height="15" rx="0" ry="0" width="90%" x="0" y="200" />
+        <rect height="15" rx="0" ry="0" width="90%" x="0" y="225" />
+      </Skeleton>
+    </GridItem>
+    <GridItem>
+      <Skeleton height={334} width="100%">
+        <rect height="180" rx="4" ry="4" width="100%" x="0" y="0" />
+        <rect height="15" rx="0" ry="0" width="90%" x="0" y="200" />
+        <rect height="15" rx="0" ry="0" width="90%" x="0" y="225" />
+      </Skeleton>
+    </GridItem>
+  </Grid>
+);
+
+export const ActionCard = () => (
+  <Grid columns="repeat(3, 1fr)" css={{ width: '100%' }} gap="large">
+    <GridItem>
+      <Skeleton height={334} width="100%">
+        <rect height="180" rx="4" ry="4" width="100%" x="0" y="0" />
+        <rect height="30" rx="0" ry="0" width="100" x="0" y="200" />
+        <rect height="15" rx="0" ry="0" width="100%" x="0" y="253" />
+        <rect height="15" rx="0" ry="0" width="100%" x="0" y="280" />
+      </Skeleton>
+    </GridItem>
+    <GridItem>
+      <Skeleton height={334} width="100%">
+        <rect height="180" rx="4" ry="4" width="100%" x="0" y="0" />
+        <rect height="30" rx="0" ry="0" width="100" x="0" y="200" />
+        <rect height="15" rx="0" ry="0" width="100%" x="0" y="253" />
+        <rect height="15" rx="0" ry="0" width="100%" x="0" y="280" />
+      </Skeleton>
+    </GridItem>
+    <GridItem>
+      <Skeleton height={334} width="100%">
+        <rect height="180" rx="4" ry="4" width="100%" x="0" y="0" />
+        <rect height="30" rx="0" ry="0" width="100" x="0" y="200" />
+        <rect height="15" rx="0" ry="0" width="100%" x="0" y="253" />
+        <rect height="15" rx="0" ry="0" width="100%" x="0" y="280" />
+      </Skeleton>
+    </GridItem>
+  </Grid>
+);
+
+export const Paragraph = () => (
+  <Skeleton>
+    <rect height="6" rx="3" ry="3" width="88" x="48" y="8" />
+    <rect height="6" rx="3" ry="3" width="52" x="48" y="26" />
+    <rect height="6" rx="3" ry="3" width="410" x="0" y="56" />
+    <rect height="6" rx="3" ry="3" width="380" x="0" y="72" />
+    <rect height="6" rx="3" ry="3" width="178" x="0" y="88" />
+    <circle cx="20" cy="20" r="20" />
+  </Skeleton>
+);
+
+export const List = () => (
+  <Skeleton>
+    <circle cx="10" cy="20" r="8" />
+    <rect height="10" rx="5" ry="5" width="220" x="25" y="15" />
+    <circle cx="10" cy="50" r="8" />
+    <rect height="10" rx="5" ry="5" width="220" x="25" y="45" />
+    <circle cx="10" cy="80" r="8" />
+    <rect height="10" rx="5" ry="5" width="220" x="25" y="75" />
+    <circle cx="10" cy="110" r="8" />
+    <rect height="10" rx="5" ry="5" width="220" x="25" y="105" />
+  </Skeleton>
+);

--- a/packages/react/components/skeleton/tests/Skeleton.test.tsx
+++ b/packages/react/components/skeleton/tests/Skeleton.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import { Skeleton } from '../src';
+
+describe('skeleton', () => {
+  it('should render', () => {
+    render(
+      <Skeleton height={196} width={325}>
+        <rect height="6" rx="3" ry="3" width="88" x="48" y="8" />
+      </Skeleton>,
+    );
+
+    expect(screen.getByRole('img')).toBeDefined();
+  });
+});

--- a/packages/react/components/skeleton/tsconfig.build.json
+++ b/packages/react/components/skeleton/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../../tsconfig.options.json",
+  "compilerOptions": {
+    "outDir": "dts",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "references": []
+}

--- a/packages/react/components/skeleton/tsconfig.json
+++ b/packages/react/components/skeleton/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "extends": "../../../../tsconfig.options.json",
+  "compilerOptions": {
+    "outDir": "../../../../.moon/cache/types/packages/react/components/skeleton"
+  },
+  "include": [
+    "src/**/*",
+    "stories/**/*",
+    "tests/**/*"
+  ],
+  "references": [
+    {
+      "path": "../../styles"
+    },
+    {
+      "path": "../../utils"
+    },
+    {
+      "path": "../../types"
+    },
+    {
+      "path": "./tsconfig.build.json"
+    }
+  ]
+}

--- a/packages/react/core/moon.yml
+++ b/packages/react/core/moon.yml
@@ -32,6 +32,7 @@ dependsOn:
   - 'portal'
   - 'provider'
   - 'side-navigation'
+  - 'skeleton'
   - 'spinner'
   - 'styles'
   - 'system'

--- a/packages/react/core/package.json
+++ b/packages/react/core/package.json
@@ -49,6 +49,7 @@
     "@project44-manifest/react-portal": "^0.1.1",
     "@project44-manifest/react-provider": "^0.3.3",
     "@project44-manifest/react-side-navigation": "^0.1.4",
+    "@project44-manifest/react-skeleton": "^0.0.0",
     "@project44-manifest/react-spinner": "^0.1.0",
     "@project44-manifest/react-styles": "^1.3.0",
     "@project44-manifest/react-table": "^1.0.1",

--- a/packages/react/core/src/index.ts
+++ b/packages/react/core/src/index.ts
@@ -72,6 +72,7 @@ export * from '@project44-manifest/react-popover';
 export * from '@project44-manifest/react-portal';
 export * from '@project44-manifest/react-provider';
 export * from '@project44-manifest/react-side-navigation';
+export * from '@project44-manifest/react-skeleton';
 export * from '@project44-manifest/react-spinner';
 export * from '@project44-manifest/react-styles';
 export * from '@project44-manifest/react-table';

--- a/packages/react/core/tsconfig.json
+++ b/packages/react/core/tsconfig.json
@@ -52,6 +52,9 @@
       "path": "../components/side-navigation"
     },
     {
+      "path": "../components/skeleton"
+    },
+    {
       "path": "../components/spinner"
     },
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -54,6 +54,9 @@
       "path": "packages/react/components/side-navigation"
     },
     {
+      "path": "packages/react/components/skeleton"
+    },
+    {
       "path": "packages/react/components/spinner"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3510,6 +3510,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@project44-manifest/react-skeleton@^0.0.0, @project44-manifest/react-skeleton@workspace:packages/react/components/skeleton":
+  version: 0.0.0-use.local
+  resolution: "@project44-manifest/react-skeleton@workspace:packages/react/components/skeleton"
+  dependencies:
+    "@project44-manifest/react-styles": ^1.0.1
+    "@project44-manifest/react-types": ^0.2.1
+    "@project44-manifest/react-utils": ^0.2.3
+    react: ^18.1.0
+    react-content-loader: ^6.2.0
+    react-dom: ^18.1.0
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+  languageName: unknown
+  linkType: soft
+
 "@project44-manifest/react-spinner@^0.1.0, @project44-manifest/react-spinner@workspace:packages/react/components/spinner":
   version: 0.0.0-use.local
   resolution: "@project44-manifest/react-spinner@workspace:packages/react/components/spinner"
@@ -3687,6 +3703,7 @@ __metadata:
     "@project44-manifest/react-portal": ^0.1.1
     "@project44-manifest/react-provider": ^0.3.3
     "@project44-manifest/react-side-navigation": ^0.1.4
+    "@project44-manifest/react-skeleton": ^0.0.0
     "@project44-manifest/react-spinner": ^0.1.0
     "@project44-manifest/react-styles": ^1.3.0
     "@project44-manifest/react-table": ^1.0.1
@@ -17763,6 +17780,15 @@ __metadata:
   peerDependencies:
     webpack: ^4.0.0 || ^5.0.0
   checksum: 51cc1b0d0e8c37c4336b5318f3b2c9c51d6998ad6f56ea09612afcfefc9c1f596341309e934a744ae907177f28efc9f1654eacd62151e82853fcc6d37450e795
+  languageName: node
+  linkType: hard
+
+"react-content-loader@npm:^6.2.0":
+  version: 6.2.0
+  resolution: "react-content-loader@npm:6.2.0"
+  peerDependencies:
+    react: ">=16.0.0"
+  checksum: a6c33ae62c3e2907a4f7f05fb1f14518927eb06608120db32064b9b32993535bb46cee92766fef4dd920658eb27662aa7bd593b1fa5ab4606c2bddd6124bfb58
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- We really appreciated your pull request! -->

Closes # <!-- Github issue # here -->

## 📝 Description

- Add skeleton placeholder loading element wrapper and examples for Card, ActionCard, generic paragraph, and generic bulleted list
  - Uses https://github.com/danilowoz/react-content-loader

## Screenshots

<img width="1215" alt="image" src="https://user-images.githubusercontent.com/3459902/222810143-833f38c6-934d-4252-9d82-5c4a6d2ea90e.png">
<img width="1228" alt="image" src="https://user-images.githubusercontent.com/3459902/222810151-f3a698a0-7858-4c6d-ab5d-94adfcf84057.png">
<img width="272" alt="image" src="https://user-images.githubusercontent.com/3459902/222810157-a3329f3b-c66b-42a8-86d1-b32c1bec2952.png">


## Merge checklist

- [x] Added/updated tests
- [x] Added changeset
