### PR TITLE
fix: website props doc filepath

### DIFF
--- a/.moon/tasks/node-library.yml
+++ b/.moon/tasks/node-library.yml
@@ -22,7 +22,7 @@ tasks:
   props-doc:
     command: 'node'
     args:
-      - './scripts/propsDoc.mjs'
+      - '../../../../scripts/propsDoc.mjs'
     inputs:
       - '@globs(sources)'
       - '@globs(typescript)'


### PR DESCRIPTION
<!--- We really appreciated your pull request! -->

Closes # <!-- Github issue # here -->

## 📝 Description

- Update Moon's filepath for `propsDoc.mjs` 
<img width="774" alt="image" src="https://user-images.githubusercontent.com/3459902/224825623-65d7fd67-664b-4bec-be83-5fa4701f79d0.png">


## Screenshots

N/A

## Merge checklist

- [ ] Added/updated tests
- [ ] Added changeset
