### PR TITLE
fix: MultiCombobox icon overlapping

### DIFF
--- a/.changeset/purple-moons-rescue.md
+++ b/.changeset/purple-moons-rescue.md
@@ -1,0 +1,5 @@
+---
+'@project44-manifest/react': minor
+---
+
+fix MultiCombobox start icon layout issue

--- a/packages/react/core/src/components/MultiCombobox/MultiCombobox.styles.ts
+++ b/packages/react/core/src/components/MultiCombobox/MultiCombobox.styles.ts
@@ -87,7 +87,7 @@ export const useStyles = css({
   variants: {
     hasStartIcon: {
       true: {
-        '.manifest-multi-combobox__input': {
+        '.manifest-multi-combobox__wrapper': {
           paddingLeft: pxToRem(40),
         },
       },

--- a/packages/react/core/stories/MultiCombobox.stories.tsx
+++ b/packages/react/core/stories/MultiCombobox.stories.tsx
@@ -1,3 +1,4 @@
+import { Search } from '@project44-manifest/react-icons';
 import type { ComponentStory } from '@storybook/react';
 import { MultiCombobox, SelectItem, SelectSection } from '../src';
 
@@ -21,4 +22,11 @@ export const Default = Template.bind({});
 
 Default.args = {
   placeholder: 'Select time...',
+};
+
+export const WithStartIcon = Template.bind({});
+
+WithStartIcon.args = {
+  placeholder: 'Select time...',
+  startIcon: <Search />,
 };


### PR DESCRIPTION
<!--- We really appreciated your pull request! -->

Closes # <!-- Github issue # here -->

## 📝 Description

- fix `MultiCombobox` start icon overlapping issue 

## Screenshots

<img width="298" alt="image" src="https://user-images.githubusercontent.com/3459902/225115318-5c4368e8-d94b-4a91-ae5d-f297795efd7b.png">
<img width="498" alt="image" src="https://user-images.githubusercontent.com/3459902/225115312-09eb620d-37ec-41f9-b524-d4cc954dd2b7.png">


## Merge checklist

- [ ] Added/updated tests
- [x] Added changeset
