### PR TITLE
fix: tooltip layout shift

### DIFF
--- a/.changeset/neat-beers-itch.md
+++ b/.changeset/neat-beers-itch.md
@@ -1,0 +1,5 @@
+---
+'@project44-manifest/react-tooltip': minor
+---
+
+fix tooltip layout shift

--- a/packages/react/components/tooltip/src/Tooltip.tsx
+++ b/packages/react/components/tooltip/src/Tooltip.tsx
@@ -58,7 +58,7 @@ export const Tooltip = React.forwardRef((props, forwardedRef) => {
       <TooltipProvider
         value={{ tooltipProps: { ...tooltipProps, ...positionProps }, tooltipRef, state }}
       >
-        <Fade appear mountOnEnter unmountOnExit in={state.isOpen}>
+        <Fade appear mountOnEnter unmountOnExit in={state.isOpen} style={{ position: 'absolute' }}>
           <TooltipContent {...other} ref={forwardedRef}>
             {title}
           </TooltipContent>

--- a/packages/react/components/tooltip/stories/Tooltip.stories.tsx
+++ b/packages/react/components/tooltip/stories/Tooltip.stories.tsx
@@ -29,3 +29,20 @@ export const Placement = () => (
     </Tooltip>
   </Stack>
 );
+
+export const IsOpen = () => (
+  <Stack css={{ marginTop: 56 }} gap="x-large" orientation="horizontal">
+    <Tooltip isOpen placement="bottom" title="bottom">
+      <Button>Hover Me</Button>
+    </Tooltip>
+    <Tooltip isOpen placement="left" title="left">
+      <Button>Hover Me</Button>
+    </Tooltip>
+    <Tooltip isOpen placement="right" title="right">
+      <Button>Hover Me</Button>
+    </Tooltip>
+    <Tooltip isOpen placement="top" title="top">
+      <Button>Hover Me</Button>
+    </Tooltip>
+  </Stack>
+);


### PR DESCRIPTION
<!--- We really appreciated your pull request! -->

Closes # <!-- Github issue # here -->

## 📝 Description

- Prevent tooltip layout shift by absolutely positioning it 

## Screenshots

<img width="514" alt="image" src="https://user-images.githubusercontent.com/3459902/225440188-b58f720c-816d-46ce-a4be-98910bc6fc1b.png">

## Merge checklist

- [ ] Added/updated tests
- [x] Added changeset
