### PR TITLE
fix: fixing safari keeping the side nav close button hovered on collapse

### DIFF
--- a/.changeset/early-cameras-worry.md
+++ b/.changeset/early-cameras-worry.md
@@ -1,0 +1,6 @@
+---
+'@project44-manifest/react': patch
+---
+
+[SideNavigation] fixing issue in safari with side navigation close staying hovered after width
+transition

--- a/packages/react/src/components/MenuGroup/MenuGroup.styles.ts
+++ b/packages/react/src/components/MenuGroup/MenuGroup.styles.ts
@@ -8,6 +8,13 @@ export const StyledMenuGroup = styled('div', {
   width: '100%',
 });
 
+export const StyledMenuGroupWrapper = styled('div', {
+  boxSizing: 'border-box',
+  display: 'flex',
+  flexDirection: 'column',
+  width: '100%',
+});
+
 export const StyledIcon = styled(ChevronDown, {
   color: '$text-secondary',
   transition: 'transform 100ms cubic-bezier(0.4, 0.14, 0.3, 1) 0ms',

--- a/packages/react/src/components/MenuGroup/MenuGroup.tsx
+++ b/packages/react/src/components/MenuGroup/MenuGroup.tsx
@@ -6,7 +6,7 @@ import { noop } from '../../utils';
 import { Collapse } from '../Collapse';
 import { MenuItem } from '../MenuItem';
 import { MenuGroupProvider } from './MenuGroup.context';
-import { StyledIcon, StyledMenuGroup } from './MenuGroup.styles';
+import { StyledIcon, StyledMenuGroup, StyledMenuGroupWrapper } from './MenuGroup.styles';
 import type { MenuGroupElement, MenuGroupProps } from './MenuGroup.types';
 
 export const MenuGroup = React.forwardRef((props, forwardedRef) => {
@@ -50,7 +50,9 @@ export const MenuGroup = React.forwardRef((props, forwardedRef) => {
       />
       <MenuGroupProvider value={{ isGrouped: true }}>
         <Collapse appear unmountOnExit duration={100} in={isExpanded}>
-          <div className="manifest-menu-group__wrapper">{children}</div>
+          <StyledMenuGroupWrapper className="manifest-menu-group__wrapper">
+            {children}
+          </StyledMenuGroupWrapper>
         </Collapse>
       </MenuGroupProvider>
     </StyledMenuGroup>

--- a/packages/react/src/components/MenuItem/MenuItem.styles.ts
+++ b/packages/react/src/components/MenuItem/MenuItem.styles.ts
@@ -12,6 +12,7 @@ export const StyledMenuItem = styled('div', {
   justifyContent: 'flex-start',
   overflow: 'hidden',
   position: 'relative',
+  my: pxToRem(2),
   px: pxToRem(12),
   textAlign: 'left',
   textDecoration: 'none',

--- a/packages/react/src/components/SideNavigation/SideNavigation.tsx
+++ b/packages/react/src/components/SideNavigation/SideNavigation.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
-import { useHover } from '@react-aria/interactions';
 import { cx } from '@project44-manifest/react-styles';
 import type { ForwardRefComponent } from '@project44-manifest/react-types';
 import { useControlledState } from '../../hooks';
-import { mergeProps, noop } from '../../utils';
+import { noop } from '../../utils';
 import { Transition } from '../Transition';
 import { NavigationProvider } from './SideNavigation.context';
 import { StyledNavigation } from './SideNavigation.styles';
@@ -21,9 +20,16 @@ export const SideNavigation = React.forwardRef((props, forwardedRef) => {
     ...other
   } = props;
 
-  const { isHovered, hoverProps } = useHover({});
-
   const [isOpen, setOpen] = useControlledState(isOpenProp!, defaultOpen ?? true, onOpenChange);
+  const [isHovered, setIsHovered] = React.useState(false);
+
+  const handleMouseEnter = React.useCallback(() => void setIsHovered(true), []);
+
+  const handleMouseLeave = React.useCallback(() => void setIsHovered(false), []);
+
+  // Handle an issue with safari and edge not trigger mouse leave events when the side
+  // navigation width changes.
+  const handleExited = React.useCallback(() => void setIsHovered(false), []);
 
   const context = React.useMemo(
     () => ({
@@ -41,14 +47,16 @@ export const SideNavigation = React.forwardRef((props, forwardedRef) => {
 
   return (
     <NavigationProvider value={context}>
-      <Transition in={isOpen}>
+      <Transition in={isOpen} onExited={handleExited}>
         <StyledNavigation
-          {...mergeProps(hoverProps, other)}
+          {...other}
           ref={forwardedRef}
           as={as}
           className={className}
           css={css}
           isOpen={isOpen}
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
         >
           {children}
         </StyledNavigation>

--- a/packages/react/src/components/SideNavigationHeader/SideNavigationHeader.tsx
+++ b/packages/react/src/components/SideNavigationHeader/SideNavigationHeader.tsx
@@ -44,7 +44,7 @@ export const SideNavigationHeader = React.forwardRef((props, forwardedRef) => {
       <StyledSideNavigationHeaderButton
         className="manifest-navigation-header__button"
         variant="tertiary"
-        onClick={handleToggle}
+        onPress={handleToggle}
       >
         {isOpen ? <Expanded /> : <Collapsed />}
       </StyledSideNavigationHeaderButton>


### PR DESCRIPTION
<!--- We really appreciated your pull request! -->

#DES-504
#DES-509

## 📝 Description

1. Adding 4px of spacing between menu items
2. Manually resetting hover state on the side navigation container for safari and edge as they do not trigger mouse leave on elements that have transitioning underneath the cursor: https://bugs.webkit.org/show_bug.cgi?id=4117

## Screenshots

> Please provide screenshots for any visual changes

## Merge checklist

- [x] Added/updated tests
- [ ] Added changeset
