### PR TITLE
feat: add useChildrenTextContent React hook 

### DIFF
--- a/.changeset/pink-bags-promise.md
+++ b/.changeset/pink-bags-promise.md
@@ -1,0 +1,5 @@
+---
+'@project44-manifest/react': minor
+---
+
+add useChildrenTextContent hook

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export * from './useChildrenTextContent';
 export * from './useControlledState';
 export * from './useDebouncedState';
 export * from './useIsomorphicLayoutEffect';

--- a/packages/react/src/hooks/useChildrenTextContent.ts
+++ b/packages/react/src/hooks/useChildrenTextContent.ts
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export function useChildrenTextContent(children?: React.ReactNode[]) {
+  const childrenTextContent = React.useMemo(
+    () =>
+      children === undefined
+        ? ''
+        : React.Children.toArray(children)
+            .filter((child) => typeof child === 'string')
+            .join(' '),
+    [children],
+  );
+
+  return childrenTextContent;
+}

--- a/packages/react/tests/useChildrenTextContent.test.tsx
+++ b/packages/react/tests/useChildrenTextContent.test.tsx
@@ -1,0 +1,44 @@
+import { renderHook } from '@testing-library/react';
+import { useChildrenTextContent } from '../src';
+
+describe('useChildrenTextContent', () => {
+  it('should return children text', () => {
+    const children: React.ReactNode[] = ['lorem ipsum'];
+    const { result } = renderHook(() => useChildrenTextContent(children));
+
+    expect(result.current).toBe('lorem ipsum');
+  });
+
+  it('should ignore non-string children', () => {
+    const children: React.ReactNode[] = [
+      <p key="1">paragraph</p>,
+      'lorem ipsum',
+      <p key="2">another paragraph</p>,
+      'dolor sit',
+      <input key="3" />,
+    ];
+    const { result } = renderHook(() => useChildrenTextContent(children));
+
+    expect(result.current).toBe('lorem ipsum dolor sit');
+  });
+
+  it('should return empty for non-text children', () => {
+    const children: React.ReactNode[] = [<p key="1">paragraph</p>];
+    const { result } = renderHook(() => useChildrenTextContent(children));
+
+    expect(result.current).toBe('');
+  });
+
+  it('should gracefully handle empty input', () => {
+    const children: React.ReactNode[] = [];
+    const { result } = renderHook(() => useChildrenTextContent(children));
+
+    expect(result.current).toBe('');
+  });
+
+  it('should gracefully handle undefined input', () => {
+    const { result } = renderHook(() => useChildrenTextContent(undefined));
+
+    expect(result.current).toBe('');
+  });
+});


### PR DESCRIPTION
<!--- We really appreciated your pull request! -->

Closes # <!-- Github issue # here -->

## 📝 Description

- Need hook for occasions such as `aria-label` and `title` which need a string that resides in the React `children` prop of the component, e.g. in Tag. Gracefully handles edge cases

## Screenshots

N/A

## Merge checklist

- [x] Added/updated tests
- [x] Added changeset
