### PR TITLE
fix(button): prevent user agent font override

### DIFF
--- a/.changeset/stale-apes-leave.md
+++ b/.changeset/stale-apes-leave.md
@@ -1,0 +1,5 @@
+---
+'@project44-manifest/react': patch
+---
+
+Fix button font-family override vulnerability user agent stylesheets

--- a/packages/react/src/components/button/button.styles.ts
+++ b/packages/react/src/components/button/button.styles.ts
@@ -11,6 +11,7 @@ export const StyledButton = styled('button', {
   color: '$text-primary',
   cursor: 'pointer',
   display: 'inline-flex',
+  fontFamily: 'inherit',
   fontSize: '$small',
   fontWeight: '$semibold',
   justifyContent: 'center',


### PR DESCRIPTION
<!--- We really appreciated your pull request! -->

Closes # <!-- Github issue # here -->

## 📝 Description

- Fix Button's vulnerability of being overridden by Chrome's user agent stylesheet
https://stackoverflow.com/questions/26140050/why-is-font-family-not-inherited-in-button-tags-automatically

## Screenshots

> Please provide screenshots for any visual changes

## Merge checklist

- [ ] Added/updated tests
- [x] Added changeset
