### PR TITLE
fix: Tag onRemove extraneous invocation

### DIFF
--- a/.changeset/tender-beans-lay.md
+++ b/.changeset/tender-beans-lay.md
@@ -1,0 +1,5 @@
+---
+'@project44-manifest/react': minor
+---
+
+fix Tag onRemove extraneous invocation

--- a/packages/react/src/components/Tag/Tag.tsx
+++ b/packages/react/src/components/Tag/Tag.tsx
@@ -75,7 +75,6 @@ export const Tag = createComponent<TagOptions>((props, forwardedRef) => {
     {
       ...removeButtonProps,
       isDisabled,
-      onClick: onRemove,
       onPress: onRemove,
     } as AriaButtonProps,
     removeButtonRef,

--- a/packages/react/tests/Tag.test.tsx
+++ b/packages/react/tests/Tag.test.tsx
@@ -18,6 +18,6 @@ describe('tag', () => {
 
     expect(screen.getByRole('button')).toBeDefined();
     fireEvent.click(screen.getByRole('button'));
-    expect(onRemove).toHaveBeenCalled();
+    expect(onRemove).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
<!--- We really appreciated your pull request! -->

Closes https://github.com/project44/manifest/issues/408

## 📝 Description

- Fix Tag `onRemove` handler extraneous invocation by removing the redundant and deprecated `onClick` handler in favor of `onPress` 

## Screenshots
<img width="160" alt="image" src="https://github.com/project44/manifest/assets/3459902/8e231ca1-fbba-4606-87bc-e4d159c345bb">

## Merge checklist

- [x] Added/updated tests
- [x] Added changeset
