### PR TITLE
fix: Pill background and update Pill examples

### DIFF
--- a/.changeset/big-peas-dance.md
+++ b/.changeset/big-peas-dance.md
@@ -1,0 +1,5 @@
+---
+'@project44-manifest/react': patch
+---
+
+Updated Pill examples with current icons

--- a/.changeset/big-peas-dance.md
+++ b/.changeset/big-peas-dance.md
@@ -1,5 +1,0 @@
----
-'@project44-manifest/react': patch
----
-
-Updated Pill examples with current icons

--- a/.changeset/five-colts-fly.md
+++ b/.changeset/five-colts-fly.md
@@ -1,0 +1,5 @@
+---
+'@project44-manifest/react': patch
+---
+
+Fix Pill styles transparent background and custom theme example

--- a/apps/website/docs/data-display/pill.mdx
+++ b/apps/website/docs/data-display/pill.mdx
@@ -37,6 +37,27 @@ Set the `isCollapsible` prop to make the pill collapse by default. The label wil
 <Pill icon={<AirplaneFilled />} isCollapsible label="In Transit" />
 ```
 
+### Custom theme
+
+An example of a custom theming
+
+```jsx live
+<Pill
+  css={{
+    backgroundColor: '$colors$palette-green-50',
+    '.manifest-pill__text': {
+      backgroundColor: 'inherit',
+      color: '$palette-green-700',
+    },
+    '.manifest-pill__icon': {
+      backgroundColor: '$palette-green-700',
+    },
+  }}
+  icon={<AirplaneFilled />}
+  label="In Transit"
+/>
+```
+
 ## Props
 
 <PropsTable component="Pill" />

--- a/apps/website/docs/data-display/pill.mdx
+++ b/apps/website/docs/data-display/pill.mdx
@@ -18,7 +18,7 @@ Represents an object or status
 Include an icon before the pill label.
 
 ```jsx live
-<Pill icon={<Icon icon="flight" />} label="In Transit" />
+<Pill icon={<AirplaneFilled />} label="In Transit" />
 ```
 
 ### Color
@@ -26,7 +26,7 @@ Include an icon before the pill label.
 Use the `colorScheme` prop to adjust the color of the pill.
 
 ```jsx live
-<Pill colorScheme="red" icon={<Icon icon="front_hand" />} label="On Hold" />
+<Pill colorScheme="red" icon={<Clock />} label="On Hold" />
 ```
 
 ### Collapsible
@@ -34,7 +34,7 @@ Use the `colorScheme` prop to adjust the color of the pill.
 Set the `isCollapsible` prop to make the pill collapse by default. The label will display on hover.
 
 ```jsx live
-<Pill icon={<Icon icon="flight" />} isCollapsible label="In Transit" />
+<Pill icon={<AirplaneFilled />} isCollapsible label="In Transit" />
 ```
 
 ## Props

--- a/packages/react/src/components/Pill/Pill.styles.ts
+++ b/packages/react/src/components/Pill/Pill.styles.ts
@@ -1,7 +1,7 @@
 import { css, pxToRem } from '@project44-manifest/react-styles';
 
 export const useStyles = css({
-  $$backgroundColor: 'tranparent',
+  $$backgroundColor: 'transparent',
 
   alignItems: 'center',
   backgroundColor: '$$backgroundColor',

--- a/packages/react/stories/Pill.stories.tsx
+++ b/packages/react/stories/Pill.stories.tsx
@@ -37,3 +37,26 @@ Collapsible.decorators = [
     </Flex>
   ),
 ];
+
+export const CustomColor = Template.bind({});
+
+CustomColor.decorators = [
+  () => (
+    <Flex align="center" css={{ gap: '$small' }}>
+      <Pill
+        css={{
+          backgroundColor: '$colors$palette-green-50',
+          '.manifest-pill__text': {
+            backgroundColor: 'inherit',
+            color: '$palette-green-700',
+          },
+          '.manifest-pill__icon': {
+            backgroundColor: '$palette-green-700',
+          },
+        }}
+        icon={<AirplaneFilled />}
+        label="In Transit"
+      />
+    </Flex>
+  ),
+];

--- a/packages/react/stories/Pill.stories.tsx
+++ b/packages/react/stories/Pill.stories.tsx
@@ -1,5 +1,6 @@
+import { AirplaneFilled, Clock } from '@project44-manifest/react-icons';
 import type { ComponentStory } from '@storybook/react';
-import { Flex, Icon, Pill } from '../src';
+import { Flex, Pill } from '../src';
 
 export default {
   title: 'Components/Pill',
@@ -11,7 +12,7 @@ const Template: ComponentStory<typeof Pill> = (args) => <Pill {...args} />;
 export const Default = Template.bind({});
 
 Default.args = {
-  icon: <Icon icon="flight" />,
+  icon: <AirplaneFilled />,
   label: 'In Transit',
 };
 
@@ -20,8 +21,8 @@ export const ColorScheme = Template.bind({});
 ColorScheme.decorators = [
   () => (
     <Flex align="center" css={{ gap: '$small' }}>
-      <Pill colorScheme="indigo" icon={<Icon icon="flight" />} label="In Transit" />
-      <Pill colorScheme="red" icon={<Icon icon="front_hand" />} label="On Hold" />
+      <Pill colorScheme="indigo" icon={<AirplaneFilled />} label="In Transit" />
+      <Pill colorScheme="red" icon={<Clock />} label="On Hold" />
     </Flex>
   ),
 ];
@@ -31,8 +32,8 @@ export const Collapsible = Template.bind({});
 Collapsible.decorators = [
   () => (
     <Flex align="center" css={{ gap: '$small' }}>
-      <Pill isCollapsible colorScheme="indigo" icon={<Icon icon="flight" />} label="In Transit" />
-      <Pill isCollapsible colorScheme="red" icon={<Icon icon="front_hand" />} label="On Hold" />
+      <Pill isCollapsible colorScheme="indigo" icon={<AirplaneFilled />} label="In Transit" />
+      <Pill isCollapsible colorScheme="red" icon={<Clock />} label="On Hold" />
     </Flex>
   ),
 ];


### PR DESCRIPTION
<!--- We really appreciated your pull request! -->

Closes # <!-- Github issue # here -->

## 📝 Description
- Updated Pill usage examples to use modern Icon components
- Fix Pill background `transparent` typo 
- Add Pill example of custom theme overrides

## Screenshots

<img width="275" alt="image" src="https://github.com/project44/manifest/assets/3459902/67a89ce1-05d2-43a2-bdab-d96f9babcc7d">

## Merge checklist

- [x] Added/updated tests
- [x] Added changeset
