### PR TITLE
fix: DataTable sticky header styling

### DIFF
--- a/.changeset/light-hats-matter.md
+++ b/.changeset/light-hats-matter.md
@@ -1,0 +1,5 @@
+---
+'@project44-manifest/react': patch
+---
+
+Fix DataTable sticky header styles

--- a/packages/react/src/components/DataTable/DataTable.styles.ts
+++ b/packages/react/src/components/DataTable/DataTable.styles.ts
@@ -90,7 +90,7 @@ export const StyledDataTable = styled('div', {
     },
 
     '&__cell--sticky-header': {
-      backgroundColor: '$$tableBackgroundColor',
+      backgroundColor: '$colors$background-secondary',
       position: 'sticky',
       top: 0,
       zIndex: 1,


### PR DESCRIPTION
<!--- We really appreciated your pull request! -->

Closes # <!-- Github issue # here -->

## 📝 Description

- Update DataTable sticky header styling for consistency 

## Screenshots

<img width="653" alt="image" src="https://github.com/project44/manifest/assets/3459902/e34c31e5-a3ed-45c8-b264-4f56111e61ac">


## Merge checklist

- [ ] Added/updated tests
- [x] Added changeset
