### PR TITLE
feat: Tooltip only render valid content

### DIFF
--- a/.changeset/great-crews-dream.md
+++ b/.changeset/great-crews-dream.md
@@ -1,0 +1,5 @@
+---
+'@project44-manifest/react': minor
+---
+
+Update Tooltip to only render when there is content to display

--- a/packages/react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.tsx
@@ -49,6 +49,11 @@ export const Tooltip = React.forwardRef((props, forwardedRef) => {
     targetRef: triggerRef,
   });
 
+  if (title === undefined || title?.toString().length === 0) {
+    // do not render tooltip if nothing to display
+    return React.cloneElement(children);
+  }
+
   return (
     <>
       {React.cloneElement(children, {


### PR DESCRIPTION
<!--- We really appreciated your pull request! -->

Closes https://github.com/project44/manifest/issues/427

## 📝 Description

- Update Tooltip only to render when there is valid content to render, e.g. eliminating this scenario of an empty tooltip rendered: 
<img width="132" alt="image" src="https://github.com/project44/manifest/assets/3459902/856f8af5-279d-4250-983f-2c7303e5772c">


## Screenshots

## Merge checklist

- [ ] Added/updated tests
- [x] Added changeset
