### PR TITLE
style: update local navigation styling to white mode

### DIFF
--- a/.changeset/fuzzy-tips-carry.md
+++ b/.changeset/fuzzy-tips-carry.md
@@ -1,0 +1,5 @@
+---
+'@project44-manifest/react': patch
+---
+
+Update Local Navigation styling to white mode

--- a/packages/react/src/components/LocalNavigation/LocalNavigation.styles.ts
+++ b/packages/react/src/components/LocalNavigation/LocalNavigation.styles.ts
@@ -2,6 +2,10 @@ import { styled } from '@project44-manifest/react-styles';
 
 export const StyledNavigation = styled('div', {
   alignItems: 'center',
+  bgColor: '$background-primary',
+  borderBottom: '1px solid $border-primary',
   display: 'flex',
   gap: '$small',
+  minH: '56px',
+  px: '$large',
 });

--- a/packages/react/src/components/LocalNavigation/components/LocalNavigationItem/LocalNavigationItem.styles.ts
+++ b/packages/react/src/components/LocalNavigation/components/LocalNavigationItem/LocalNavigationItem.styles.ts
@@ -7,9 +7,10 @@ export const StyledItem = styled('button', {
   border: 'none',
   borderRadius: '$small',
   boxSizing: 'border-box',
-  color: '$palette-indigo-50',
+  color: '$text-primary',
   cursor: 'pointer',
   display: 'inline-flex',
+  fontFamily: 'inherit',
   outline: 'none',
   position: 'relative',
   p: `${pxToRem(6)} ${pxToRem(12)}`,
@@ -18,23 +19,19 @@ export const StyledItem = styled('button', {
   whiteSpace: 'nowrap',
 
   '&:active': {
-    backgroundColor: '$palette-white',
-    color: '$text-primary',
+    backgroundColor: '$background-tertiary',
   },
 
   '&:hover': {
-    backgroundColor: 'rgba(255, 255, 255, 0.2)',
-    color: '$text-contrast',
+    backgroundColor: '$background-secondary',
   },
 
   '&.manifest-local-navigation-item--selected': {
-    backgroundColor: '$palette-white',
-    color: '$text-primary',
+    backgroundColor: '$background-tertiary',
     typography: '$subtext-bold',
 
     '&:hover, &:active': {
-      backgroundColor: '$palette-white',
-      color: '$text-primary',
+      backgroundColor: '$background-tertiary',
     },
   },
 });

--- a/packages/react/stories/LocalNavigation.stories.tsx
+++ b/packages/react/stories/LocalNavigation.stories.tsx
@@ -1,4 +1,4 @@
-import { Flex, LocalNavigation, LocalNavigationItem } from '../src';
+import { LocalNavigation, LocalNavigationItem } from '../src';
 
 export default {
   title: 'Components/LocalNavigation',
@@ -7,29 +7,19 @@ export default {
 };
 
 export const Default = () => (
-  <Flex
-    align="center"
-    css={{ backgroundColor: '$background-top-nav', height: '56px', px: '$large' }}
-  >
-    <LocalNavigation>
-      <LocalNavigationItem>Overview</LocalNavigationItem>
-      <LocalNavigationItem>Lanes</LocalNavigationItem>
-      <LocalNavigationItem>Carriers</LocalNavigationItem>
-      <LocalNavigationItem>Containers</LocalNavigationItem>
-    </LocalNavigation>
-  </Flex>
+  <LocalNavigation>
+    <LocalNavigationItem>Overview</LocalNavigationItem>
+    <LocalNavigationItem>Lanes</LocalNavigationItem>
+    <LocalNavigationItem>Carriers</LocalNavigationItem>
+    <LocalNavigationItem>Containers</LocalNavigationItem>
+  </LocalNavigation>
 );
 
 export const Selected = () => (
-  <Flex
-    align="center"
-    css={{ backgroundColor: '$background-top-nav', height: '56px', px: '$large' }}
-  >
-    <LocalNavigation>
-      <LocalNavigationItem isSelected>Overview</LocalNavigationItem>
-      <LocalNavigationItem>Lanes</LocalNavigationItem>
-      <LocalNavigationItem>Carriers</LocalNavigationItem>
-      <LocalNavigationItem>Containers</LocalNavigationItem>
-    </LocalNavigation>
-  </Flex>
+  <LocalNavigation>
+    <LocalNavigationItem isSelected>Overview</LocalNavigationItem>
+    <LocalNavigationItem>Lanes</LocalNavigationItem>
+    <LocalNavigationItem>Carriers</LocalNavigationItem>
+    <LocalNavigationItem>Containers</LocalNavigationItem>
+  </LocalNavigation>
 );


### PR DESCRIPTION
Closes # <!-- Github issue # here -->

## 📝 Description
This PR changes the styling of `LocalNavigation` component to match white mode.

## Ticket
https://project44.atlassian.net/browse/INITIATE-2126

## Screenshots
<img width="878" alt="Screenshot 2023-08-07 at 16 04 31" src="https://github.com/project44/manifest/assets/90175251/259589dc-cd11-4eee-80f7-1bfc41a91fe1">

## Merge checklist

- [ ] Added/updated tests
- [x] Added changeset
