### PR TITLE
fix: local navigation styling, add white mode variant

### DIFF
--- a/.changeset/polite-melons-warn.md
+++ b/.changeset/polite-melons-warn.md
@@ -1,0 +1,6 @@
+---
+'@project44-manifest/react': patch
+---
+
+Fix LocalNavigation default styling to previous blue one. Add new LocalNavigation variant for white
+mode.

--- a/apps/website/docs/navigation/local-navigation.mdx
+++ b/apps/website/docs/navigation/local-navigation.mdx
@@ -7,15 +7,34 @@ sidebar_custom_props:
 
 Navigation component for sections or pages
 
+## Appearance
+
+Use the `variant` prop to display primary or secondary variant of the component
+
+### Primary
+
+Mainly for use with sidebars.
+
 ```jsx live
-<Flex align="center" css={{ backgroundColor: '$background-top-nav', height: '56px', px: '$large' }}>
-  <LocalNavigation>
-    <LocalNavigationItem>Overview</LocalNavigationItem>
-    <LocalNavigationItem>Lanes</LocalNavigationItem>
-    <LocalNavigationItem>Carriers</LocalNavigationItem>
-    <LocalNavigationItem>Containers</LocalNavigationItem>
-  </LocalNavigation>
-</Flex>
+<LocalNavigation css={{ flex: 1 }}>
+  <LocalNavigationItem>Overview</LocalNavigationItem>
+  <LocalNavigationItem>Lanes</LocalNavigationItem>
+  <LocalNavigationItem>Carriers</LocalNavigationItem>
+  <LocalNavigationItem>Containers</LocalNavigationItem>
+</LocalNavigation>
+```
+
+### Secondary
+
+Mainly for use on white pages as a navigation in header.
+
+```jsx live
+<LocalNavigation css={{ flex: 1 }} variant="secondary">
+  <LocalNavigationItem>Overview</LocalNavigationItem>
+  <LocalNavigationItem>Lanes</LocalNavigationItem>
+  <LocalNavigationItem>Carriers</LocalNavigationItem>
+  <LocalNavigationItem>Containers</LocalNavigationItem>
+</LocalNavigation>
 ```
 
 ## Usage
@@ -25,14 +44,12 @@ Navigation component for sections or pages
 Use the `isSelected` prop to indicate current location
 
 ```jsx live
-<Flex align="center" css={{ backgroundColor: '$background-top-nav', height: '56px', px: '$large' }}>
-  <LocalNavigation>
-    <LocalNavigationItem isSelected>Overview</LocalNavigationItem>
-    <LocalNavigationItem>Lanes</LocalNavigationItem>
-    <LocalNavigationItem>Carriers</LocalNavigationItem>
-    <LocalNavigationItem>Containers</LocalNavigationItem>
-  </LocalNavigation>
-</Flex>
+<LocalNavigation css={{ flex: 1 }}>
+  <LocalNavigationItem isSelected>Overview</LocalNavigationItem>
+  <LocalNavigationItem>Lanes</LocalNavigationItem>
+  <LocalNavigationItem>Carriers</LocalNavigationItem>
+  <LocalNavigationItem>Containers</LocalNavigationItem>
+</LocalNavigation>
 ```
 
 ## Props

--- a/packages/react/docs.json
+++ b/packages/react/docs.json
@@ -1205,6 +1205,13 @@
       "type": "boolean",
       "required": false,
       "description": "Whether the navigation item is currently selected"
+    },
+    {
+      "name": "variant",
+      "type": "LocalNavigationVariant",
+      "defaultValue": "'primary'",
+      "required": false,
+      "description": "The display variant."
     }
   ],
   "LocalNavigation": [
@@ -1213,6 +1220,13 @@
       "type": "CSS",
       "required": false,
       "description": "Theme aware style object"
+    },
+    {
+      "name": "variant",
+      "type": "LocalNavigationVariant",
+      "defaultValue": "'primary'",
+      "required": false,
+      "description": "The display variant."
     }
   ],
   "Menu": [

--- a/packages/react/src/components/LocalNavigation/LocalNavigation.styles.ts
+++ b/packages/react/src/components/LocalNavigation/LocalNavigation.styles.ts
@@ -2,10 +2,19 @@ import { styled } from '@project44-manifest/react-styles';
 
 export const StyledNavigation = styled('div', {
   alignItems: 'center',
-  bgColor: '$background-primary',
-  borderBottom: '1px solid $border-primary',
   display: 'flex',
   gap: '$small',
   minH: '56px',
   px: '$large',
+  variants: {
+    variant: {
+      primary: {
+        bgColor: '$background-top-nav',
+      },
+      secondary: {
+        bgColor: '$background-primary',
+        borderBottom: '1px solid $border-primary',
+      },
+    },
+  },
 });

--- a/packages/react/src/components/LocalNavigation/LocalNavigation.tsx
+++ b/packages/react/src/components/LocalNavigation/LocalNavigation.tsx
@@ -1,17 +1,55 @@
 import * as React from 'react';
 import { CSS, cx } from '@project44-manifest/react-styles';
 import type { ForwardRefComponent } from '@project44-manifest/react-types';
+import { createContext } from '../../utils/context';
 import { StyledNavigation } from './LocalNavigation.styles';
+
+export type LocalNavigationVariant = 'primary' | 'secondary';
+
+/* -------------------------------------------------------------------------------------------------
+ * LocalNavigationContext
+ * -----------------------------------------------------------------------------------------------*/
+
+interface LocalNavigationContext {
+  variant?: LocalNavigationVariant;
+}
+
+export const [LocalNavigationProvider, useLocalNavigation] = createContext<LocalNavigationContext>({
+  name: 'LocalNavigationContext',
+});
+
+/* -------------------------------------------------------------------------------------------------
+ * LocalNavigation
+ * -----------------------------------------------------------------------------------------------*/
 
 export interface LocalNavigationProps {
   /** Theme aware style object */
   css?: CSS;
+  /**
+   * The display variant.
+   *
+   * @default 'primary'
+   */
+  variant?: LocalNavigationVariant;
 }
 
 export const LocalNavigation = React.forwardRef((props, forwardedRef) => {
-  const { as, className: classNameProp, css, ...other } = props;
+  const { as, children, className: classNameProp, css, variant = 'primary', ...other } = props;
+
+  const context = React.useMemo(() => ({ variant }), [variant]);
 
   const className = cx('manifest-local-navigation', classNameProp);
 
-  return <StyledNavigation {...other} ref={forwardedRef} as={as} className={className} css={css} />;
+  return (
+    <StyledNavigation
+      {...other}
+      ref={forwardedRef}
+      as={as}
+      className={className}
+      css={css}
+      variant={variant}
+    >
+      <LocalNavigationProvider value={context}>{children}</LocalNavigationProvider>
+    </StyledNavigation>
+  );
 }) as ForwardRefComponent<'div', LocalNavigationProps>;

--- a/packages/react/src/components/LocalNavigation/components/LocalNavigationItem/LocalNavigationItem.styles.ts
+++ b/packages/react/src/components/LocalNavigation/components/LocalNavigationItem/LocalNavigationItem.styles.ts
@@ -7,7 +7,6 @@ export const StyledItem = styled('button', {
   border: 'none',
   borderRadius: '$small',
   boxSizing: 'border-box',
-  color: '$text-primary',
   cursor: 'pointer',
   display: 'inline-flex',
   fontFamily: 'inherit',
@@ -18,20 +17,52 @@ export const StyledItem = styled('button', {
   userSelect: 'none',
   whiteSpace: 'nowrap',
 
-  '&:active': {
-    backgroundColor: '$background-tertiary',
-  },
+  variants: {
+    variant: {
+      primary: {
+        color: '$palette-indigo-50',
 
-  '&:hover': {
-    backgroundColor: '$background-secondary',
-  },
+        '&:active': {
+          backgroundColor: '$palette-white',
+          color: '$text-primary',
+        },
 
-  '&.manifest-local-navigation-item--selected': {
-    backgroundColor: '$background-tertiary',
-    typography: '$subtext-bold',
+        '&:hover': {
+          backgroundColor: 'rgba(255, 255, 255, 0.2)',
+          color: '$text-contrast',
+        },
 
-    '&:hover, &:active': {
-      backgroundColor: '$background-tertiary',
+        '&.manifest-local-navigation-item--selected': {
+          backgroundColor: '$palette-white',
+          color: '$text-primary',
+          typography: '$subtext-bold',
+
+          '&:hover, &:active': {
+            backgroundColor: '$palette-white',
+            color: '$text-primary',
+          },
+        },
+      },
+      secondary: {
+        color: '$text-primary',
+
+        '&:active': {
+          backgroundColor: '$background-tertiary',
+        },
+
+        '&:hover': {
+          backgroundColor: '$background-secondary',
+        },
+
+        '&.manifest-local-navigation-item--selected': {
+          backgroundColor: '$background-tertiary',
+          typography: '$subtext-bold',
+
+          '&:hover, &:active': {
+            backgroundColor: '$background-tertiary',
+          },
+        },
+      },
     },
   },
 });

--- a/packages/react/src/components/LocalNavigation/components/LocalNavigationItem/LocalNavigationItem.tsx
+++ b/packages/react/src/components/LocalNavigation/components/LocalNavigationItem/LocalNavigationItem.tsx
@@ -6,6 +6,7 @@ import { mergeProps, mergeRefs } from '@react-aria/utils';
 import type { AriaButtonProps } from '@react-types/button';
 import { CSS, cx } from '@project44-manifest/react-styles';
 import type { ForwardRefComponent } from '@project44-manifest/react-types';
+import { LocalNavigationVariant, useLocalNavigation } from '../../LocalNavigation';
 import { StyledItem } from './LocalNavigationItem.styles';
 
 export interface LocalNavigationItemProps extends AriaButtonProps {
@@ -13,10 +14,26 @@ export interface LocalNavigationItemProps extends AriaButtonProps {
   css?: CSS;
   /** Whether the navigation item is currently selected */
   isSelected?: boolean;
+  /**
+   * The display variant.
+   *
+   * @default 'primary'
+   */
+  variant?: LocalNavigationVariant;
 }
 
 export const LocalNavigationItem = React.forwardRef((props, forwardedRef) => {
-  const { as, autoFocus, className: classNameProp, css, isSelected, ...other } = props;
+  const localNavigation = useLocalNavigation();
+
+  const {
+    as,
+    autoFocus,
+    className: classNameProp,
+    css,
+    isSelected,
+    variant = localNavigation?.variant ?? 'primary',
+    ...other
+  } = props;
 
   const itemRef = React.useRef<HTMLButtonElement>(null);
 
@@ -48,6 +65,7 @@ export const LocalNavigationItem = React.forwardRef((props, forwardedRef) => {
       as={as}
       className={className}
       css={css}
+      variant={variant}
     />
   );
 }) as ForwardRefComponent<'button', LocalNavigationItemProps>;

--- a/packages/react/stories/LocalNavigation.stories.tsx
+++ b/packages/react/stories/LocalNavigation.stories.tsx
@@ -1,4 +1,4 @@
-import { LocalNavigation, LocalNavigationItem } from '../src';
+import { LocalNavigation, LocalNavigationItem, Stack, Typography } from '../src';
 
 export default {
   title: 'Components/LocalNavigation',
@@ -13,6 +13,25 @@ export const Default = () => (
     <LocalNavigationItem>Carriers</LocalNavigationItem>
     <LocalNavigationItem>Containers</LocalNavigationItem>
   </LocalNavigation>
+);
+
+export const Variant = () => (
+  <Stack gap="large">
+    <Typography variant="subtextBold">Primary</Typography>
+    <LocalNavigation>
+      <LocalNavigationItem isSelected>Overview</LocalNavigationItem>
+      <LocalNavigationItem>Lanes</LocalNavigationItem>
+      <LocalNavigationItem>Carriers</LocalNavigationItem>
+      <LocalNavigationItem>Containers</LocalNavigationItem>
+    </LocalNavigation>
+    <Typography variant="subtextBold">Secondary</Typography>
+    <LocalNavigation variant="secondary">
+      <LocalNavigationItem isSelected>Overview</LocalNavigationItem>
+      <LocalNavigationItem>Lanes</LocalNavigationItem>
+      <LocalNavigationItem>Carriers</LocalNavigationItem>
+      <LocalNavigationItem>Containers</LocalNavigationItem>
+    </LocalNavigation>
+  </Stack>
 );
 
 export const Selected = () => (


### PR DESCRIPTION
Closes # <!-- Github issue # here -->

## 📝 Description
This PR fixes the default styles for `LocalNavigation` component, and adds new variant for white mode.

## Ticket
https://project44.atlassian.net/browse/INITIATE-2126

## Screenshots
<img width="862" alt="Screenshot 2023-08-09 at 12 35 27" src="https://github.com/project44/manifest/assets/90175251/4b89f47c-cd5d-4411-99d9-b42270fb4098">
<img width="1267" alt="Screenshot 2023-08-09 at 13 19 58" src="https://github.com/project44/manifest/assets/90175251/c283108b-f4d9-4811-80ce-fd7659769296">


## Merge checklist

- [ ] Added/updated tests
- [x] Added changeset
