### PR TITLE
feat: add dropdown item to local navigation

### DIFF
--- a/.changeset/eleven-coats-tan.md
+++ b/.changeset/eleven-coats-tan.md
@@ -1,0 +1,5 @@
+---
+'@project44-manifest/react': minor
+---
+
+LocalNavigationDropdownItem added for using dropdown button in LocalNavigation component.

--- a/apps/website/docs/navigation/local-navigation.mdx
+++ b/apps/website/docs/navigation/local-navigation.mdx
@@ -35,11 +35,34 @@ Use the `isSelected` prop to indicate current location
 </Flex>
 ```
 
+### With dropdown button
+
+Use the `LocalNavigationDropdownItem` component to display a button item with dropdown
+
+```jsx live
+<LocalNavigation>
+  <LocalNavigationDropdownItem title="Parent section">
+    <DropdownMenu>
+      <DropdownItem key="Profile">Profile</DropdownItem>
+      <DropdownItem key="Search">Search</DropdownItem>
+    </DropdownMenu>
+  </LocalNavigationDropdownItem>
+  <LocalNavigationItem>Overview</LocalNavigationItem>
+  <LocalNavigationItem>Lanes</LocalNavigationItem>
+  <LocalNavigationItem>Carriers</LocalNavigationItem>
+  <LocalNavigationItem>Containers</LocalNavigationItem>
+</LocalNavigation>
+```
+
 ## Props
 
 ### LocalNavigation Props
 
 <PropsTable component="LocalNavigation" />
+
+### LocalNavigationDropdownItem Props
+
+<PropsTable component="LocalNavigationDropdownItem" />
 
 ### LocalNavigationItem Props
 

--- a/apps/website/docs/navigation/local-navigation.mdx
+++ b/apps/website/docs/navigation/local-navigation.mdx
@@ -5,11 +5,11 @@ sidebar_custom_props:
   status: 'production'
 ---
 
-Navigation component for sections or pages
+Navigation component for sections or pages.
 
 ## Appearance
 
-Use the `variant` prop to display primary or secondary variant of the component
+Use the `variant` prop to display primary or secondary variant of the component.
 
 ### Primary
 
@@ -41,7 +41,7 @@ Mainly for use on white pages as a navigation in header.
 
 ### Selected
 
-Use the `isSelected` prop to indicate current location
+Use the `isSelected` prop to indicate current location.
 
 ```jsx live
 <LocalNavigation css={{ flex: 1 }}>
@@ -54,7 +54,7 @@ Use the `isSelected` prop to indicate current location
 
 ### With dropdown button
 
-Use the `LocalNavigationDropdownItem` component to display a button item with dropdown
+Use the `LocalNavigationDropdownItem` component to display a button item with dropdown.
 
 ```jsx live
 <LocalNavigation>

--- a/packages/react/docs.json
+++ b/packages/react/docs.json
@@ -1193,6 +1193,99 @@
   ],
   "ListBoxItem": [],
   "ListBoxSection": [],
+  "LocalNavigationDropdownItem": [
+    {
+      "name": "children",
+      "type": "ReactNode",
+      "required": false,
+      "description": "Should contain DropdownMenu with DropdownItems"
+    },
+    {
+      "name": "css",
+      "type": "CSS",
+      "required": false,
+      "description": "Theme aware style object"
+    },
+    {
+      "name": "localNavigationItemProps",
+      "type": "AriaButtonProps<\"button\">",
+      "required": false,
+      "description": "Props passed down to LocalNavigationItem"
+    },
+    {
+      "name": "title",
+      "type": "ReactNode",
+      "required": false,
+      "description": "Title of LocalNavigationItem"
+    },
+    {
+      "name": "isDisabled",
+      "type": "boolean",
+      "defaultValue": "false",
+      "required": false,
+      "description": "Whether menu trigger is disabled."
+    },
+    {
+      "name": "type",
+      "type": "\"menu\" | \"listbox\"",
+      "defaultValue": "'menu'",
+      "required": false,
+      "description": "The type of menu that the menu trigger opens."
+    },
+    {
+      "name": "offset",
+      "type": "number",
+      "defaultValue": "4",
+      "required": false,
+      "description": "The additional offset applied along the main axis between the element and its\nanchor element."
+    },
+    {
+      "name": "placement",
+      "type": "Placement",
+      "defaultValue": "'bottom'",
+      "required": false,
+      "description": "The placement of the element with respect to its anchor element."
+    },
+    {
+      "name": "shouldFlip",
+      "type": "boolean",
+      "defaultValue": "true",
+      "required": false,
+      "description": "Whether the element should flip its orientation (e.g. top to bottom or left to right) when\nthere is insufficient room for it to render completely."
+    },
+    {
+      "name": "onOpenChange",
+      "type": "(isOpen: boolean) => void",
+      "required": false,
+      "description": "Handler that is called when the overlay's open state changes."
+    },
+    {
+      "name": "isOpen",
+      "type": "boolean",
+      "required": false,
+      "description": "Whether the overlay is open by default (controlled)."
+    },
+    {
+      "name": "defaultOpen",
+      "type": "boolean",
+      "required": false,
+      "description": "Whether the overlay is open by default (uncontrolled)."
+    },
+    {
+      "name": "closeOnSelect",
+      "type": "boolean",
+      "defaultValue": "true",
+      "required": false,
+      "description": "Whether the dropdown closes when a selection is made."
+    },
+    {
+      "name": "trigger",
+      "type": "MenuTriggerType",
+      "defaultValue": "'press'",
+      "required": false,
+      "description": "How the menu is triggered."
+    }
+  ],
   "LocalNavigationItem": [
     {
       "name": "css",

--- a/packages/react/docs.json
+++ b/packages/react/docs.json
@@ -1198,25 +1198,25 @@
       "name": "children",
       "type": "ReactNode",
       "required": false,
-      "description": "Should contain DropdownMenu with DropdownItems"
+      "description": "Should contain DropdownMenu with DropdownItems."
     },
     {
       "name": "css",
       "type": "CSS",
       "required": false,
-      "description": "Theme aware style object"
+      "description": "Theme aware style object."
     },
     {
       "name": "localNavigationItemProps",
       "type": "AriaButtonProps<\"button\">",
       "required": false,
-      "description": "Props passed down to LocalNavigationItem"
+      "description": "Props passed down to LocalNavigationItem."
     },
     {
       "name": "title",
       "type": "ReactNode",
       "required": false,
-      "description": "Title of LocalNavigationItem"
+      "description": "Title of LocalNavigationItem."
     },
     {
       "name": "isDisabled",

--- a/packages/react/src/components/LocalNavigation/components/LocalNavigationDropdownItem/LocalNavigationDropdownItem.tsx
+++ b/packages/react/src/components/LocalNavigation/components/LocalNavigationDropdownItem/LocalNavigationDropdownItem.tsx
@@ -7,13 +7,13 @@ import { Dropdown, DropdownProps } from '../../../Dropdown';
 import { LocalNavigationItem } from '../LocalNavigationItem';
 
 export interface LocalNavigationDropdownItemProps extends Omit<DropdownProps, 'children'> {
-  /** Should contain DropdownMenu with DropdownItems */
+  /** Should contain DropdownMenu with DropdownItems. */
   children: ReactNode;
-  /** Theme aware style object */
+  /** Theme aware style object. */
   css?: CSS;
-  /** Props passed down to LocalNavigationItem */
+  /** Props passed down to LocalNavigationItem. */
   localNavigationItemProps?: AriaButtonProps;
-  /** Title of LocalNavigationItem */
+  /** Title of LocalNavigationItem. */
   title: ReactNode | string;
 }
 

--- a/packages/react/src/components/LocalNavigation/components/LocalNavigationDropdownItem/LocalNavigationDropdownItem.tsx
+++ b/packages/react/src/components/LocalNavigation/components/LocalNavigationDropdownItem/LocalNavigationDropdownItem.tsx
@@ -1,0 +1,65 @@
+import React, { ReactNode, useCallback, useState } from 'react';
+import { AriaButtonProps } from '@react-aria/button';
+import { ChevronDown } from '@project44-manifest/react-icons';
+import { CSS, cx } from '@project44-manifest/react-styles';
+import type { ForwardRefComponent } from '@project44-manifest/react-types';
+import { Dropdown, DropdownProps } from '../../../Dropdown';
+import { LocalNavigationItem } from '../LocalNavigationItem';
+
+export interface LocalNavigationDropdownItemProps extends Omit<DropdownProps, 'children'> {
+  /** Should contain DropdownMenu with DropdownItems */
+  children: ReactNode;
+  /** Theme aware style object */
+  css?: CSS;
+  /** Props passed down to LocalNavigationItem */
+  localNavigationItemProps?: AriaButtonProps;
+  /** Title of LocalNavigationItem */
+  title: ReactNode | string;
+}
+
+export const LocalNavigationDropdownItem = React.forwardRef((props, forwardedRef) => {
+  const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
+
+  const {
+    as,
+    children,
+    className: classNameProp,
+    css,
+    localNavigationItemProps,
+    title,
+    ...other
+  } = props;
+  const className = cx('manifest-local-navigation-dropdown-item', classNameProp);
+
+  const handleOpenChange = useCallback(
+    (isOpen: boolean) => {
+      setIsMenuOpen(isOpen);
+      other?.onOpenChange?.(isOpen);
+    },
+    [other],
+  );
+
+  return (
+    <Dropdown {...(other as DropdownProps)} onOpenChange={handleOpenChange}>
+      <LocalNavigationItem
+        {...localNavigationItemProps}
+        ref={forwardedRef}
+        as={as}
+        className={className}
+        css={{ gap: '$small', pr: '$small', typography: '$subtext-bold', ...css }}
+        isSelected={isMenuOpen}
+      >
+        {title}
+        <ChevronDown
+          css={{
+            transform: `rotate(${isMenuOpen ? -180 : 0}deg)`,
+            transformOrigin: '50% 54%',
+            transition: 'transform 100ms',
+          }}
+          size="small"
+        />
+      </LocalNavigationItem>
+      {children}
+    </Dropdown>
+  );
+}) as ForwardRefComponent<'button', LocalNavigationDropdownItemProps>;

--- a/packages/react/src/components/LocalNavigation/components/LocalNavigationDropdownItem/index.ts
+++ b/packages/react/src/components/LocalNavigation/components/LocalNavigationDropdownItem/index.ts
@@ -1,2 +1,1 @@
 export * from './LocalNavigationDropdownItem';
-export * from './LocalNavigationItem';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -65,8 +65,16 @@ export type { ListBoxItemProps } from './components/ListBoxItem';
 export { ListBoxItem } from './components/ListBoxItem';
 export type { ListBoxSectionProps } from './components/ListBoxSection';
 export { ListBoxSection } from './components/ListBoxSection';
-export type { LocalNavigationItemProps, LocalNavigationProps } from './components/LocalNavigation';
-export { LocalNavigation, LocalNavigationItem } from './components/LocalNavigation';
+export type {
+  LocalNavigationDropdownItemProps,
+  LocalNavigationItemProps,
+  LocalNavigationProps,
+} from './components/LocalNavigation';
+export {
+  LocalNavigation,
+  LocalNavigationDropdownItem,
+  LocalNavigationItem,
+} from './components/LocalNavigation';
 export type { MenuElement, MenuProps } from './components/Menu';
 export { Menu } from './components/Menu';
 export type { MenuGroupElement, MenuGroupProps } from './components/MenuGroup';

--- a/packages/react/stories/LocalNavigation.stories.tsx
+++ b/packages/react/stories/LocalNavigation.stories.tsx
@@ -1,4 +1,5 @@
-import { LocalNavigation, LocalNavigationItem } from '../src';
+import { DropdownItem, DropdownMenu, LocalNavigation, LocalNavigationItem } from '../src';
+import { LocalNavigationDropdownItem } from '../src/components/LocalNavigation';
 
 export default {
   title: 'Components/LocalNavigation',
@@ -18,6 +19,21 @@ export const Default = () => (
 export const Selected = () => (
   <LocalNavigation>
     <LocalNavigationItem isSelected>Overview</LocalNavigationItem>
+    <LocalNavigationItem>Lanes</LocalNavigationItem>
+    <LocalNavigationItem>Carriers</LocalNavigationItem>
+    <LocalNavigationItem>Containers</LocalNavigationItem>
+  </LocalNavigation>
+);
+
+export const WithDropdown = () => (
+  <LocalNavigation>
+    <LocalNavigationDropdownItem title="Parent section">
+      <DropdownMenu>
+        <DropdownItem key="Profile">Profile</DropdownItem>
+        <DropdownItem key="Search">Search</DropdownItem>
+      </DropdownMenu>
+    </LocalNavigationDropdownItem>
+    <LocalNavigationItem>Overview</LocalNavigationItem>
     <LocalNavigationItem>Lanes</LocalNavigationItem>
     <LocalNavigationItem>Carriers</LocalNavigationItem>
     <LocalNavigationItem>Containers</LocalNavigationItem>

--- a/packages/react/tests/LocalNavigation.test.tsx
+++ b/packages/react/tests/LocalNavigation.test.tsx
@@ -1,5 +1,11 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { LocalNavigation, LocalNavigationItem } from '../src';
+import {
+  DropdownItem,
+  DropdownMenu,
+  LocalNavigation,
+  LocalNavigationDropdownItem,
+  LocalNavigationItem,
+} from '../src';
 
 describe('react: LocalNavigation', () => {
   it('should render', () => {
@@ -57,5 +63,30 @@ describe('react: LocalNavigation', () => {
     fireEvent.click(button[0]);
 
     expect(onPress).toHaveBeenCalled();
+  });
+
+  it('should render dropdown item and dropdown options after click', () => {
+    const onOpenChange = jest.fn();
+
+    render(
+      <LocalNavigation>
+        <LocalNavigationDropdownItem title="Parent section" onOpenChange={onOpenChange}>
+          <DropdownMenu>
+            <DropdownItem key="Profile">Profile</DropdownItem>
+            <DropdownItem key="Search">Search</DropdownItem>
+          </DropdownMenu>
+        </LocalNavigationDropdownItem>
+        <LocalNavigationItem>Overview</LocalNavigationItem>
+      </LocalNavigation>,
+    );
+
+    const button = screen.getAllByRole('button');
+
+    fireEvent.click(button[0]);
+
+    const dropdownOption = screen.getByRole('menuitem', { name: 'Profile' });
+
+    expect(onOpenChange).toHaveBeenCalled();
+    expect(dropdownOption).toBeVisible();
   });
 });


### PR DESCRIPTION
Closes # <!-- Github issue # here -->

## 📝 Description
This PR adds new `LocalNavigationDropdownItem` component that can be used with `LocalNavigation`.

## Ticket
https://project44.atlassian.net/browse/INITIATE-2153

## Screenshots
<img width="853" alt="Screenshot 2023-08-09 at 13 44 15" src="https://github.com/project44/manifest/assets/90175251/1af84623-9f41-4ddd-b6f1-5ccdecd15334">
<img width="849" alt="Screenshot 2023-08-09 at 13 44 23" src="https://github.com/project44/manifest/assets/90175251/0b4ed95b-98cc-4d3b-8a81-7e863caec633">
<img width="1297" alt="Screenshot 2023-08-09 at 14 08 01" src="https://github.com/project44/manifest/assets/90175251/1a8cd4e9-1c1d-41ab-9dab-70a886872255">


## Merge checklist

- [x] Added/updated tests
- [x] Added changeset
