### PR TITLE
chore(Skeleton): Removed use of react.useId in skeleton component

### DIFF
--- a/.changeset/tough-poems-appear.md
+++ b/.changeset/tough-poems-appear.md
@@ -1,0 +1,5 @@
+---
+'@project44-manifest/react': minor
+---
+
+Removed use of useId from manifest skeleton component

--- a/packages/react/src/components/Skeleton/Skeleton.tsx
+++ b/packages/react/src/components/Skeleton/Skeleton.tsx
@@ -8,11 +8,7 @@ export function Skeleton(props: SkeletonProps) {
   const className = cx('manifest-skeleton', classNameProp);
 
   return (
-    <StyledSkeleton
-      {...other}
-      className={className}
-      css={css}
-    >
+    <StyledSkeleton {...other} className={className} css={css}>
       {children}
     </StyledSkeleton>
   );

--- a/packages/react/src/components/Skeleton/Skeleton.tsx
+++ b/packages/react/src/components/Skeleton/Skeleton.tsx
@@ -1,12 +1,9 @@
-import * as React from 'react';
 import { cx } from '@project44-manifest/react-styles';
 import { StyledSkeleton } from './Skeleton.styles';
 import type { SkeletonProps } from './Skeleton.types';
 
 export function Skeleton(props: SkeletonProps) {
   const { children, className: classNameProp, css, ...other } = props;
-
-  const id = React.useId();
 
   const className = cx('manifest-skeleton', classNameProp);
 
@@ -15,7 +12,6 @@ export function Skeleton(props: SkeletonProps) {
       {...other}
       className={className}
       css={css}
-      uniqueKey={id} // needed for SSR: https://github.com/danilowoz/react-content-loader#sedrver-side-rendering-ssr---match-snapshot
     >
       {children}
     </StyledSkeleton>


### PR DESCRIPTION
## 📝 Description
Removed use of `React.useId` from manifest skelton

re: https://p-44.slack.com/archives/C01HJ79UKT9/p1691524901968509

An issue was uncovered  where we are using React 18 feature (useId namely) in manifest that we can't polyfill to the version of react we are using in `micro-webapps` (react 17). This issue can be recreated if the `isLoading` props is used on `DataTable`, which utilizes Skeleton.

The presence of this hook was to satisfy a server side rendering requirement - which is not applicable to our applications. 

If a presence of a unique `key` props is required, it should be up to the implementor to pass its value.

## Screenshots
None

## Merge checklist
- [x] Added/updated tests
- [x] Added changeset
