### PR TITLE
fix: keep multiselect menu open on option click

### DIFF
--- a/.changeset/wicked-dragons-crash.md
+++ b/.changeset/wicked-dragons-crash.md
@@ -1,0 +1,5 @@
+---
+'@project44-manifest/react': patch
+---
+
+fix: disblaed auto dismiss for MultiComboBox menu

--- a/packages/react/src/state/useMultiComboboxState.ts
+++ b/packages/react/src/state/useMultiComboboxState.ts
@@ -84,10 +84,7 @@ export function useMultiComboboxState<T extends object>(
     items: items ?? defaultItems,
     onSelectionChange: (keys: Selection) => {
       onSelectionChange?.(keys);
-
       resetInputValue();
-
-      triggerState.close();
     },
   });
 


### PR DESCRIPTION
<!--- We really appreciated your pull request! -->

Closes # <!-- Github issue # here -->

## 📝 Description
This PR fixes auto dismiss issue in `MultiComboBox` component.
The options menu gets dismissed on selecting a single options, but it should persist for user to select multiple options at once

## Ticket
https://project44.atlassian.net/browse/DES-540

## Screenshots

### MultiComboBox with auto dismiss disabled
https://github.com/project44/manifest/assets/137487111/dd00e10e-8676-4c9c-b5d2-9e1f96d600f1



## Merge checklist

- [ ] Added/updated tests
- [ ] Added changeset
