### PR TITLE
fix: Checkbox colors for active, hover and focussed states

### DIFF
--- a/.changeset/breezy-trains-collect.md
+++ b/.changeset/breezy-trains-collect.md
@@ -1,0 +1,5 @@
+---
+'@project44-manifest/react': patch
+---
+
+fix: checkbox colors for active, hover and foucssed states

--- a/packages/design-tokens/src/opacity/opacity.json
+++ b/packages/design-tokens/src/opacity/opacity.json
@@ -1,0 +1,7 @@
+{
+  "opacity": {
+    "disabled": {
+      "value": 0.38
+    }
+  }
+}

--- a/packages/react-styles/src/theme.ts
+++ b/packages/react-styles/src/theme.ts
@@ -193,6 +193,9 @@ const theme = {
     'text-tertiary': tokens.colorTextTertiary,
     'text-warning': tokens.colorTextWarning,
   },
+  opacity: {
+    disabled: tokens.opacityDisabled
+  },
   fonts: {
     character: "'Noto Sans', sans-serif",
     mono: tokens.fontFamilyMono,

--- a/packages/react-styles/src/theme.ts
+++ b/packages/react-styles/src/theme.ts
@@ -194,7 +194,7 @@ const theme = {
     'text-warning': tokens.colorTextWarning,
   },
   opacity: {
-    disabled: tokens.opacityDisabled
+    disabled: tokens.opacityDisabled,
   },
   fonts: {
     character: "'Noto Sans', sans-serif",

--- a/packages/react/src/components/Checkbox/Checkbox.styles.ts
+++ b/packages/react/src/components/Checkbox/Checkbox.styles.ts
@@ -64,6 +64,11 @@ export const useStyles = css({
         pointerEvents: 'none',
       },
     },
+    isActive: {
+      true: {
+        $$borderColor: '$colors$palette-grey-800',
+      }
+    },
     isFocusVisible: {
       true: {
         '.manifest-checkbox__control': {
@@ -120,6 +125,14 @@ export const useStyles = css({
       css: {
         $$backgroundColor: '$colors$primary-default',
         $$borderColor: '$colors$primary-default',
+      },
+    },
+    {
+      isChecked: true,
+      isActive: true,
+      css: {
+        $$backgroundColor: '$colors$primary-active',
+        $$borderColor: '$colors$primary-active',
       },
     },
   ],

--- a/packages/react/src/components/Checkbox/Checkbox.styles.ts
+++ b/packages/react/src/components/Checkbox/Checkbox.styles.ts
@@ -53,8 +53,8 @@ export const useStyles = css({
   variants: {
     isChecked: {
       true: {
-        $$backgroundColor: '$colors$primary-active',
-        $$borderColor: '$colors$primary-active',
+        $$backgroundColor: '$colors$primary-default',
+        $$borderColor: '$colors$primary-default',
       },
     },
     isDisabled: {

--- a/packages/react/src/components/Checkbox/Checkbox.styles.ts
+++ b/packages/react/src/components/Checkbox/Checkbox.styles.ts
@@ -67,7 +67,7 @@ export const useStyles = css({
     isActive: {
       true: {
         $$borderColor: '$colors$palette-grey-800',
-      }
+      },
     },
     isFocusVisible: {
       true: {

--- a/packages/react/src/components/Checkbox/Checkbox.styles.ts
+++ b/packages/react/src/components/Checkbox/Checkbox.styles.ts
@@ -53,14 +53,14 @@ export const useStyles = css({
   variants: {
     isChecked: {
       true: {
-        $$backgroundColor: '$colors$primary-default',
-        $$borderColor: '$colors$primary-default',
+        $$backgroundColor: '$colors$primary-active',
+        $$borderColor: '$colors$primary-active',
       },
     },
     isDisabled: {
       true: {
         cursor: 'not-allowed',
-        opacity: 0.58,
+        opacity: 0.38,
         pointerEvents: 'none',
       },
     },
@@ -102,13 +102,23 @@ export const useStyles = css({
       isChecked: true,
       isHovered: true,
       css: {
-        $$borderColor: '$colors$primary-default',
+        $$backgroundColor: '$colors$primary-hover',
+        $$borderColor: '$colors$primary-hover',
       },
     },
     {
       isIndeterminate: true,
       isHovered: true,
       css: {
+        $$backgroundColor: '$colors$primary-hover',
+        $$borderColor: '$colors$primary-hover',
+      },
+    },
+    {
+      isChecked: true,
+      isFocusVisible: true,
+      css: {
+        $$backgroundColor: '$colors$primary-default',
         $$borderColor: '$colors$primary-default',
       },
     },

--- a/packages/react/src/components/Checkbox/Checkbox.styles.ts
+++ b/packages/react/src/components/Checkbox/Checkbox.styles.ts
@@ -60,7 +60,7 @@ export const useStyles = css({
     isDisabled: {
       true: {
         cursor: 'not-allowed',
-        opacity: 0.38,
+        opacity: '$opacity$disabled',
         pointerEvents: 'none',
       },
     },

--- a/packages/react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.tsx
@@ -38,7 +38,7 @@ export const Checkbox = createComponent<CheckboxOptions>((props, forwardedRef) =
   const { inputProps } = useCheckbox(props, state, inputRef);
   const { isFocusVisible, focusProps } = useFocusRing({ autoFocus });
   const { isHovered, hoverProps } = useHover({ isDisabled });
-  const { pressProps } = usePress({ isDisabled: inputProps.disabled });
+  const { pressProps, isPressed } = usePress({ isDisabled: inputProps.disabled });
 
   const { className } = useStyles({
     css,
@@ -47,6 +47,7 @@ export const Checkbox = createComponent<CheckboxOptions>((props, forwardedRef) =
     isFocusVisible,
     isHovered,
     isIndeterminate,
+    isActive: isPressed,
   });
 
   const classes = cx(className, classNameProp, {


### PR DESCRIPTION
<!--- We really appreciated your pull request! -->

Closes # <!-- Github issue # here -->

## 📝 Description
Fixed the colours for Checkbox component following Figma for Active, Hover and Focussed states

> Add a brief description

## Screenshots

> Please provide screenshots for any visual changes

## Merge checklist

- [ ] Added/updated tests
- [ ] Added changeset
