### PR TITLE
fix: modal errors

### DIFF
--- a/.changeset/nervous-mayflies-admire.md
+++ b/.changeset/nervous-mayflies-admire.md
@@ -1,5 +1,5 @@
 ---
-'@project44-manifest/react': major
+'@project44-manifest/react': patch
 ---
 
 fix modal error after close

--- a/.changeset/nervous-mayflies-admire.md
+++ b/.changeset/nervous-mayflies-admire.md
@@ -1,0 +1,5 @@
+---
+'@project44-manifest/react': major
+---
+
+fix modal error after close

--- a/packages/react/src/components/Overlay/Overlay.tsx
+++ b/packages/react/src/components/Overlay/Overlay.tsx
@@ -9,7 +9,7 @@ export function Overlay(props: OverlayProps) {
 
   return (
     <ReactAriaOverlay portalContainer={portalContainer!}>
-      {isOpen && <Provider>{children}</Provider>}
+      <Provider>{isOpen && children}</Provider>
     </ReactAriaOverlay>
   );
 }


### PR DESCRIPTION
## 📝 Description

Fixing the error after modal close:
Uncaught TypeError: Cannot read properties of undefined (reading 'previousElementSibling')

## Screenshots

<img width="691" alt="image" src="https://github.com/project44/manifest/assets/109169910/8c289dce-4837-4a07-92a6-b78ba9f428d0">

## Merge checklist

- [x] Added/updated tests
- [x] Added changeset
