### PR TITLE
fix: Console warnings

### DIFF
--- a/.changeset/popular-bottles-care.md
+++ b/.changeset/popular-bottles-care.md
@@ -1,0 +1,7 @@
+---
+'@project44-manifest/react': patch
+---
+
+- Fix aria warnings for RadioGroup, SegmentControl
+- Fix left: NaN error in DatePicker, DateRangePicker
+- Fix onClick, onPress warnings in Tooltip, LocalNavigationItem

--- a/packages/react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.tsx
@@ -135,6 +135,15 @@ export const DatePicker = createComponent<DatePickerOptions>((props, forwardedRe
     targetRef: containerRef,
   });
 
+  // TODO find real solution
+  const overlayPositionProps = {
+    ...overlayProps,
+    style:{
+      ...overlayProps.style,
+      left: isNaN(overlayProps.left) ? 0 : overlayProps.left
+    }
+  }
+
   const isInvalid = validationState === 'invalid';
 
   const { buttonProps, isPressed } = useButton({ ...triggerProps, isDisabled }, triggerRef);
@@ -211,7 +220,7 @@ export const DatePicker = createComponent<DatePickerOptions>((props, forwardedRe
 
         <Overlay containerRef={containerRefProp} isOpen={state.isOpen}>
           <Popover
-            {...mergeProps(dialogProps, overlayProps)}
+            {...mergeProps(dialogProps, overlayPositionProps)}
             ref={popoverRef}
             className="manifest-datepicker__popover"
             isOpen={state.isOpen}

--- a/packages/react/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/packages/react/src/components/DateRangePicker/DateRangePicker.tsx
@@ -164,6 +164,15 @@ export const DateRangePicker = createComponent<DateRangePickerOptions>((props, f
     targetRef: containerRef,
   });
 
+  // TODO find real solution
+  const overlayPositionProps = {
+    ...overlayProps,
+    style:{
+      ...overlayProps.style,
+      left: isNaN(overlayProps.left) ? 0 : overlayProps.left
+    }
+  }
+
   const isInvalid = validationState === 'invalid';
 
   const { buttonProps, isPressed } = useButton({ ...triggerProps, isDisabled }, triggerRef);
@@ -247,7 +256,7 @@ export const DateRangePicker = createComponent<DateRangePickerOptions>((props, f
 
         <Overlay containerRef={containerRefProp} isOpen={state.isOpen}>
           <Popover
-            {...mergeProps(dialogProps, overlayProps)}
+            {...mergeProps(dialogProps, overlayPositionProps)}
             ref={popoverRef}
             className="manifest-datepicker__popover"
             isOpen={state.isOpen}

--- a/packages/react/src/components/LocalNavigation/components/LocalNavigationItem/LocalNavigationItem.tsx
+++ b/packages/react/src/components/LocalNavigation/components/LocalNavigationItem/LocalNavigationItem.tsx
@@ -33,11 +33,13 @@ export const LocalNavigationItem = React.forwardRef((props, forwardedRef) => {
     isSelected,
     variant = localNavigation?.variant ?? 'primary',
     onPress, // omit onPress from mergeProps
+    onPressStart, // omit onPressStart fromm mergeProps
     ...other
   } = props;
 
   const itemRef = React.useRef<HTMLButtonElement>(null);
 
+  // TODO buttonProps returns onClick - fix onClick deprecated warning
   const { buttonProps, isPressed } = useButton(
     {
       ...props,

--- a/packages/react/src/components/LocalNavigation/components/LocalNavigationItem/LocalNavigationItem.tsx
+++ b/packages/react/src/components/LocalNavigation/components/LocalNavigationItem/LocalNavigationItem.tsx
@@ -32,6 +32,7 @@ export const LocalNavigationItem = React.forwardRef((props, forwardedRef) => {
     css,
     isSelected,
     variant = localNavigation?.variant ?? 'primary',
+    onPress, // omit onPress from mergeProps
     ...other
   } = props;
 

--- a/packages/react/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/react/src/components/RadioGroup/RadioGroup.tsx
@@ -37,6 +37,7 @@ export const RadioGroup = createComponent<RadioGroupOptions>((props, forwardedRe
 
   const state = useRadioGroupState(props);
   const { radioGroupProps } = useRadioGroup(props, state);
+  const { isDisabled: disabled, ...rest } = radioGroupProps;
 
   const context = React.useMemo(() => ({ state }), [state]);
 
@@ -48,8 +49,13 @@ export const RadioGroup = createComponent<RadioGroupOptions>((props, forwardedRe
   });
 
   return (
-    <Comp {...mergeProps(radioGroupProps, other)} ref={forwardedRef} className={classes}>
-      <RadioGroupContext.Provider value={context}>{children}</RadioGroupContext.Provider>
+    <Comp
+      {...mergeProps(radioGroupProps, { disabled, ...rest })}
+      ref={forwardedRef}
+      className={classes}>
+      <RadioGroupContext.Provider value={context}>
+        {children}
+      </RadioGroupContext.Provider>
     </Comp>
   );
 });

--- a/packages/react/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/react/src/components/SegmentedControl/SegmentedControl.tsx
@@ -22,7 +22,10 @@ export const SegmentedControl = React.forwardRef((props, forwardedRef) => {
 
   const state = useRadioGroupState(props);
 
-  const { radioGroupProps } = useRadioGroup(props, state);
+  const { radioGroupProps } = useRadioGroup({
+    'aria-label': props?.value || 'Radio Group',
+    ...props
+  }, state);
 
   const className = cx('manifest-segmented-control', classNameProp);
 

--- a/packages/react/src/components/SegmentedControl/components/Segment/Segment.tsx
+++ b/packages/react/src/components/SegmentedControl/components/Segment/Segment.tsx
@@ -40,7 +40,10 @@ export const Segment = React.forwardRef((props, forwardedRef) => {
 
   const state = useSegmentedControl();
 
-  const { inputProps } = useRadio(props, state, inputRef);
+  const { inputProps } = useRadio({
+    'aria-label': props.value,
+    ...props
+  }, state, inputRef);
   const { isFocusVisible, focusProps } = useFocusRing({ autoFocus });
   const { isHovered, hoverProps } = useHover({});
   const { pressProps, isPressed } = usePress({});

--- a/packages/react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.tsx
@@ -35,6 +35,7 @@ export const Tooltip = React.forwardRef((props, forwardedRef) => {
     trigger,
   });
 
+  // TODO triggerProps returns onClick - fix onClick deprecated warning
   const { tooltipProps, triggerProps } = useTooltipTrigger(
     { isDisabled, trigger },
     state,
@@ -54,20 +55,10 @@ export const Tooltip = React.forwardRef((props, forwardedRef) => {
     return React.cloneElement(children);
   }
 
-  const {
-    onClick, // Omit onClick
-    ...rest
-  } = triggerProps
-
-  const onPress = (event) =>{
-    event.currentTarget = event?.currentTarget || event.target;
-    triggerProps.onClick(event)
-  }
-
   return (
     <>
       {React.cloneElement(children, {
-        ...(mergeProps(children.props, {...rest, onPress }) as React.Attributes),
+        ...(mergeProps(children.props, triggerProps) as React.Attributes),
         ref: triggerRef,
       })}
 

--- a/packages/react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.tsx
@@ -54,10 +54,20 @@ export const Tooltip = React.forwardRef((props, forwardedRef) => {
     return React.cloneElement(children);
   }
 
+  const {
+    onClick, // Omit onClick
+    ...rest
+  } = triggerProps
+
+  const onPress = (event) =>{
+    event.currentTarget = event?.currentTarget || event.target;
+    triggerProps.onClick(event)
+  }
+
   return (
     <>
       {React.cloneElement(children, {
-        ...(mergeProps(children.props, triggerProps) as React.Attributes),
+        ...(mergeProps(children.props, {...rest, onPress }) as React.Attributes),
         ref: triggerRef,
       })}
 


### PR DESCRIPTION
<!--- We really appreciated your pull request! -->

Closes #
https://github.com/project44/manifest/issues/397

## 📝 Description

- Fix aria warnings for `RadioGroup, SegmentControl`
- Fix `left: NaN` error in `DatePicker, DateRangePicker`
- Fix `onClick, onPress` warnings in `Tooltip, LocalNavigationItem`

## Dev Comments

The `left: NaN` error is likely from a `window.getComputedStyle` call or something similar, and should be solved by mocking the appropriate function rather than the current awkward catch

For `Tooltip, LocalNavigationItem` the `react-aria` package hooks such as `useButton, useTooltipTrigger` return `onClick` handlers by default. This is passed to the `button` or other interactive child element according to the html specs. React considers this deprecated and throws spammy `onClick is deprecated, use onPress instead` warnings in unit tests. However this cannot simply be swapped out in the pass down as native html elements like `button` do not support `onPress` in the way a jsx `Button` does. We need to find a solution that removes the warnings but preserves behavior.

## Screenshots

- N/A

## Merge checklist

- [X] Added/updated tests
- [ ] Added changeset
