### PR TITLE
fix: set month value based on monthIndex for new Date

### DIFF
--- a/packages/react/src/components/CalendarRanges/defaultDefinedRanges.ts
+++ b/packages/react/src/components/CalendarRanges/defaultDefinedRanges.ts
@@ -16,22 +16,23 @@ export const createCalendarDate = (date: Date) => {
 
 export const addDays = (calendarDate: CalendarDate, days: number) => {
   const { day, month, year } = calendarDate;
-  const date = new Date(year, month, day);
-  date.setDate(date.getDate() + days);
+  // Date constructor expects monthIndex instead of month, i.e Jan - 0, Feb - 1 and so on
+  const date = new Date(year, month - 1, day);
+  date.setDate(date.getDate() + days + 1);
   return calendarDate.set({
     day: date.getDate(),
-    month: date.getMonth(),
+    month: date.getMonth() + 1,
     year: date.getFullYear(),
   });
 };
 
 export const addMonths = (calendarDate: CalendarDate, months: number) => {
   const { day, month, year } = calendarDate;
-  const date = new Date(year, month, day);
+  const date = new Date(year, month - 1, day);
   date.setMonth(date.getMonth() + months);
   return calendarDate.set({
     day: date.getDate(),
-    month: date.getMonth(),
+    month: date.getMonth() + 1,
     year: date.getFullYear(),
   });
 };


### PR DESCRIPTION
<!--- We really appreciated your pull request! -->
## 📝 Description
The date range picker sets range incorrectly when relative range is selected

## Screenshots
|       Bug     |      Fix      |
|-----------|----------|
| <img width="500" alt="DateRangeBug" src="https://github.com/project44/manifest/assets/137487111/b12c50bb-8d2a-404c-8391-d9a7b68b3485"> | <img width="500" alt="DateRangeFix" src="https://github.com/project44/manifest/assets/137487111/23fc5c33-5db3-46c5-9b52-91d3cbbeaa80"> |

## Merge checklist

- [ ] Added/updated tests
- [ ] Added changeset
