### PR TITLE
feat: datatable total footer support for pinning

### DIFF
--- a/.changeset/dull-grapes-raise.md
+++ b/.changeset/dull-grapes-raise.md
@@ -1,0 +1,5 @@
+---
+'@project44-manifest/react': minor
+---
+
+Added support for totsl footer row in datatable

--- a/.changeset/dull-grapes-raise.md
+++ b/.changeset/dull-grapes-raise.md
@@ -2,4 +2,4 @@
 '@project44-manifest/react': minor
 ---
 
-Added support for totsl footer row in datatable
+Added support for totals footer row in datatable

--- a/packages/react/src/components/DataTable/DataTable.tsx
+++ b/packages/react/src/components/DataTable/DataTable.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import * as React from 'react';
 import { cx } from '@project44-manifest/react-styles';
 import {

--- a/packages/react/src/components/DataTable/DataTable.tsx
+++ b/packages/react/src/components/DataTable/DataTable.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import * as React from 'react';
 import { cx } from '@project44-manifest/react-styles';
 import {
@@ -23,7 +22,7 @@ import {
 } from './components';
 import { DataTableFooter } from './components/DataTableFooter/DataTableFooter';
 import { StyledDataTable } from './DataTable.styles';
-import type { DataTable, DataTableProps } from './DataTable.types';
+import type { DataTable, DataTableProps, TotalsProps } from './DataTable.types';
 
 export function DataTable<TData extends RowData>(props: DataTableProps<TData>) {
   const {

--- a/packages/react/src/components/DataTable/DataTable.tsx
+++ b/packages/react/src/components/DataTable/DataTable.tsx
@@ -22,7 +22,7 @@ import {
 } from './components';
 import { DataTableFooter } from './components/DataTableFooter/DataTableFooter';
 import { StyledDataTable } from './DataTable.styles';
-import type { DataTable, DataTableProps, TotalsProps } from './DataTable.types';
+import type { DataTable, DataTableProps } from './DataTable.types';
 
 export function DataTable<TData extends RowData>(props: DataTableProps<TData>) {
   const {

--- a/packages/react/src/components/DataTable/DataTable.types.ts
+++ b/packages/react/src/components/DataTable/DataTable.types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import type { CSS } from '@project44-manifest/react-styles';
 import type {
   ColumnDef,
@@ -196,6 +197,12 @@ export interface DataTableProps<TData extends RowData> {
       index: number,
       keyword: string,
     ) => number | string;
+    /**
+     * Whether the table header should stick when scrolling vertically
+     *
+     * @default false
+     */
+    enableSticky?: boolean;
   };
 
   /**
@@ -256,7 +263,13 @@ export interface footerPropsType {
     headerId: number | string,
     index: number,
     keyword: string,
-  ) => number | string;
+  ) => any;
+    /**
+   * Whether the table header should stick when scrolling vertically
+   *
+   * @default false
+   */
+    enableSticky?: boolean;
 }
 
 export interface TotalsProps {
@@ -264,6 +277,6 @@ export interface TotalsProps {
   totalsKeyword: string;
 }
 
-export type TotalsDataObj = Record<string, TotalsHeaderObj<unknown>>;
+export type TotalsDataObj = Record<string, TotalsHeaderObj<any>>;
 
 export type TotalsHeaderObj<T> = Record<string, T>;

--- a/packages/react/src/components/DataTable/DataTable.types.ts
+++ b/packages/react/src/components/DataTable/DataTable.types.ts
@@ -243,7 +243,7 @@ export interface DataTableProps<TData extends RowData> {
   onSortingChange?: OnChangeFn<SortingState>;
 }
 
-export interface footerPropsType {
+export interface FooterPropsType {
   /**
    * Props passed to the Total footer component
    * if these prop is missing total footer wont be rendered

--- a/packages/react/src/components/DataTable/DataTable.types.ts
+++ b/packages/react/src/components/DataTable/DataTable.types.ts
@@ -264,12 +264,12 @@ export interface footerPropsType {
     index: number,
     keyword: string,
   ) => any;
-    /**
+  /**
    * Whether the table header should stick when scrolling vertically
    *
    * @default false
    */
-    enableSticky?: boolean;
+  enableSticky?: boolean;
 }
 
 export interface TotalsProps {

--- a/packages/react/src/components/DataTable/DataTable.types.ts
+++ b/packages/react/src/components/DataTable/DataTable.types.ts
@@ -176,34 +176,7 @@ export interface DataTableProps<TData extends RowData> {
   /**
    * prop to enable total footer
    */
-  footerProps?: {
-    /**
-     * Props passed to the Total footer component
-     * if these prop is missing total footer wont be rendered
-     */
-    data: TotalsDataObj;
-    /**
-     * Props passed to the Total footer keyword
-     *
-     */
-    keyword: string;
-    /**
-     * callBack function for passing value to totalcolumns
-     * if these prop is missing total footer wont be rendered
-     */
-    callBackFunc: (
-      data: TotalsDataObj,
-      headerId: number | string,
-      index: number,
-      keyword: string,
-    ) => number | string;
-    /**
-     * Whether the table header should stick when scrolling vertically
-     *
-     * @default false
-     */
-    enableSticky?: boolean;
-  };
+  footerProps?: FooterPropsType;
 
   /**
    * The total number of rows for the total table (controlled).

--- a/packages/react/src/components/DataTable/components/DataTableFooter/DataTableFooter.types.ts
+++ b/packages/react/src/components/DataTable/components/DataTableFooter/DataTableFooter.types.ts
@@ -1,8 +1,8 @@
 import { RowData } from '@tanstack/react-table';
-import type { DataTable, footerPropsType } from '../../DataTable.types';
+import type { DataTable, FooterPropsType } from '../../DataTable.types';
 
 export interface DataTableFooterProps<TData extends RowData> {
   enableStickyFooter?: boolean;
   table: DataTable<TData>;
-  footerProps: footerPropsType;
+  footerProps: FooterPropsType;
 }

--- a/packages/react/src/components/DataTable/components/DataTableFooter/DataTableFooter.types.ts
+++ b/packages/react/src/components/DataTable/components/DataTableFooter/DataTableFooter.types.ts
@@ -6,4 +6,3 @@ export interface DataTableFooterProps<TData extends RowData> {
   table: DataTable<TData>;
   footerProps: footerPropsType;
 }
-

--- a/packages/react/src/components/DataTable/components/DataTableFooter/DataTableFooter.types.ts
+++ b/packages/react/src/components/DataTable/components/DataTableFooter/DataTableFooter.types.ts
@@ -6,3 +6,4 @@ export interface DataTableFooterProps<TData extends RowData> {
   table: DataTable<TData>;
   footerProps: footerPropsType;
 }
+

--- a/packages/react/src/components/DataTable/components/DataTableFooterColumn/DataTableFooterColumn.tsx
+++ b/packages/react/src/components/DataTable/components/DataTableFooterColumn/DataTableFooterColumn.tsx
@@ -23,7 +23,6 @@ export function DataTableFooterColumn<TData extends RowData, TVaue>(
     <th
       key={header.id}
       className={cx('manifest-table__cell', 'manifest-table__cell--header', {
-        // 'manifest-table__cell--sticky-header': table.options.enableStickyHeader,
         'manifest-table__cell--pinned': column.getIsPinned(),
       })}
       colSpan={header.colSpan}

--- a/packages/react/src/components/DataTable/components/DataTableFooterColumn/DataTableFooterColumn.tsx
+++ b/packages/react/src/components/DataTable/components/DataTableFooterColumn/DataTableFooterColumn.tsx
@@ -1,4 +1,3 @@
-
 import * as React from 'react';
 import { cx } from '@project44-manifest/react-styles';
 import { flexRender, RowData } from '@tanstack/react-table';
@@ -13,7 +12,7 @@ export function DataTableFooterColumn<TData extends RowData, TVaue>(
   const { data, keyword, callBackFunc } = footerProps;
 
   const styles: React.CSSProperties = getColumnLayoutStyles(table, column);
-  
+
   return (
     <th
       key={header.id}

--- a/packages/react/src/components/DataTable/components/DataTableFooterColumn/DataTableFooterColumn.tsx
+++ b/packages/react/src/components/DataTable/components/DataTableFooterColumn/DataTableFooterColumn.tsx
@@ -1,3 +1,4 @@
+
 import * as React from 'react';
 import { cx } from '@project44-manifest/react-styles';
 import { flexRender, RowData } from '@tanstack/react-table';
@@ -12,7 +13,7 @@ export function DataTableFooterColumn<TData extends RowData, TVaue>(
   const { data, keyword, callBackFunc } = footerProps;
 
   const styles: React.CSSProperties = getColumnLayoutStyles(table, column);
-
+  
   return (
     <th
       key={header.id}

--- a/packages/react/src/components/DataTable/components/DataTableFooterColumn/DataTableFooterColumn.tsx
+++ b/packages/react/src/components/DataTable/components/DataTableFooterColumn/DataTableFooterColumn.tsx
@@ -10,15 +10,14 @@ export function DataTableFooterColumn<TData extends RowData, TVaue>(
 ) {
   const { header, table, footerProps, index } = props;
   const { column } = header;
-  const { data, keyword, callBackFunc,enableSticky } = footerProps;
-
+  const { data, keyword, callBackFunc, enableSticky } = footerProps;
 
   const styles: React.CSSProperties = getColumnLayoutStyles(table, column);
-  const sticky :React.CSSProperties ={
+  const sticky: React.CSSProperties = {
     position: 'sticky',
-    bottom:'0px',
+    bottom: '0px',
     zIndex: 0,
-  }
+  };
 
   return (
     <th
@@ -27,14 +26,11 @@ export function DataTableFooterColumn<TData extends RowData, TVaue>(
         // 'manifest-table__cell--sticky-header': table.options.enableStickyHeader,
         'manifest-table__cell--pinned': column.getIsPinned(),
       })}
-      
       colSpan={header.colSpan}
-      style={
-        {
+      style={{
         ...(enableSticky ? sticky : {}),
-        ...styles
+        ...styles,
       }}
-
     >
       {flexRender(callBackFunc?.(data, header.id, index, keyword), header.getContext())}
     </th>

--- a/packages/react/src/components/DataTable/components/DataTableFooterColumn/DataTableFooterColumn.tsx
+++ b/packages/react/src/components/DataTable/components/DataTableFooterColumn/DataTableFooterColumn.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 import * as React from 'react';
 import { cx } from '@project44-manifest/react-styles';
 import { flexRender, RowData } from '@tanstack/react-table';
@@ -9,19 +10,31 @@ export function DataTableFooterColumn<TData extends RowData, TVaue>(
 ) {
   const { header, table, footerProps, index } = props;
   const { column } = header;
-  const { data, keyword, callBackFunc } = footerProps;
+  const { data, keyword, callBackFunc,enableSticky } = footerProps;
+
 
   const styles: React.CSSProperties = getColumnLayoutStyles(table, column);
+  const sticky :React.CSSProperties ={
+    position: 'sticky',
+    bottom:'0px',
+    zIndex: 0,
+  }
 
   return (
     <th
       key={header.id}
       className={cx('manifest-table__cell', 'manifest-table__cell--header', {
-        'manifest-table__cell--sticky-header': table.options.enableStickyHeader,
-        'manifest-table__cell--pinned': '',
+        // 'manifest-table__cell--sticky-header': table.options.enableStickyHeader,
+        'manifest-table__cell--pinned': column.getIsPinned(),
       })}
+      
       colSpan={header.colSpan}
-      style={{ ...styles }}
+      style={
+        {
+        ...(enableSticky ? sticky : {}),
+        ...styles
+      }}
+
     >
       {flexRender(callBackFunc?.(data, header.id, index, keyword), header.getContext())}
     </th>

--- a/packages/react/src/components/DataTable/components/DataTableFooterColumn/DataTableFooterColumnProps.types.ts
+++ b/packages/react/src/components/DataTable/components/DataTableFooterColumn/DataTableFooterColumnProps.types.ts
@@ -1,9 +1,9 @@
 import { Header, RowData } from '@tanstack/react-table';
-import type { DataTable, footerPropsType } from '../../DataTable.types';
+import type { DataTable, FooterPropsType } from '../../DataTable.types';
 
 export interface DataTableFooterColumnProps<TData extends RowData, TVaue> {
   header: Header<TData, TVaue>;
   table: DataTable<TData>;
   index: number;
-  footerProps: footerPropsType;
+  footerProps: FooterPropsType;
 }

--- a/packages/react/stories/DataTable.stories.tsx
+++ b/packages/react/stories/DataTable.stories.tsx
@@ -36,46 +36,46 @@ export const Default = () => {
     {
       header: 'First Name',
       accessorKey: 'firstName',
-      footer: (props )=> props.column.id
+      footer: (props) => props.column.id,
     },
     {
       header: 'Last Name',
       accessorKey: 'lastName',
-      footer: props => props.column.id,
+      footer: (props) => props.column.id,
     },
     {
       header: 'Gender',
       accessorKey: 'gender',
-      footer: props => props.column.id,
+      footer: (props) => props.column.id,
     },
     {
       header: 'Age',
       accessorKey: 'age',
-      footer: props => props.column.id,
+      footer: (props) => props.column.id,
     },
     {
       header: 'Address',
       accessorKey: 'address',
-      footer: props => props.column.id,
+      footer: (props) => props.column.id,
     },
     {
       header: 'City',
       accessorKey: 'city',
-      footer: props => props.column.id,
+      footer: (props) => props.column.id,
     },
     {
       header: 'Subscribed',
       accessorKey: 'isSubscribed',
-      footer: props => props.column.id,
+      footer: (props) => props.column.id,
     },
     {
       header: 'Birthday',
       accessorKey: 'birthday',
-      footer: props => props.column.id,
+      footer: (props) => props.column.id,
     },
   ];
 
-  return <DataTable columns={columns} data={data}/>;
+  return <DataTable columns={columns} data={data} />;
 };
 
 export const CustomCellRendering = () => {

--- a/packages/react/stories/DataTable.stories.tsx
+++ b/packages/react/stories/DataTable.stories.tsx
@@ -36,42 +36,34 @@ export const Default = () => {
     {
       header: 'First Name',
       accessorKey: 'firstName',
-      footer: (props) => props.column.id,
     },
     {
       header: 'Last Name',
       accessorKey: 'lastName',
-      footer: (props) => props.column.id,
     },
     {
       header: 'Gender',
       accessorKey: 'gender',
-      footer: (props) => props.column.id,
     },
     {
       header: 'Age',
       accessorKey: 'age',
-      footer: (props) => props.column.id,
     },
     {
       header: 'Address',
       accessorKey: 'address',
-      footer: (props) => props.column.id,
     },
     {
       header: 'City',
       accessorKey: 'city',
-      footer: (props) => props.column.id,
     },
     {
       header: 'Subscribed',
       accessorKey: 'isSubscribed',
-      footer: (props) => props.column.id,
     },
     {
       header: 'Birthday',
       accessorKey: 'birthday',
-      footer: (props) => props.column.id,
     },
   ];
 

--- a/packages/react/stories/DataTable.stories.tsx
+++ b/packages/react/stories/DataTable.stories.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { faker } from '@faker-js/faker';
 import { ClipboardWithCheck, Clock } from '@project44-manifest/react-icons';
 import { createDataTableColumnHelper, DataTable, DataTableColumnDef, Link, Pill } from '../src';
@@ -409,7 +408,7 @@ export const TotalFooterRow = () => {
     isSubscribed: boolean;
     birthday: string;
   }
-  const data = [...Array.from({ length: 5 })].map(() => ({
+  const data = [...Array.from({ length: 10 })].map(() => ({
     firstName: faker.name.firstName(),
     lastName: faker.name.lastName(),
     gender: faker.name.sex(),
@@ -507,9 +506,10 @@ export const TotalFooterRow = () => {
     data: totalsData,
     keyword: totalsKeyword,
     callBackFunc: getTotalValue,
+    enableSticky: true,
   };
 
   return (
-    <DataTable columns={columns} data={data} enablePagination={false} footerProps={footerObj} />
+    <DataTable enableStickyHeader columns={columns} data={data} enablePagination={false} footerProps={footerObj} />
   );
 };

--- a/packages/react/stories/DataTable.stories.tsx
+++ b/packages/react/stories/DataTable.stories.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { faker } from '@faker-js/faker';
 import { ClipboardWithCheck, Clock } from '@project44-manifest/react-icons';
 import { createDataTableColumnHelper, DataTable, DataTableColumnDef, Link, Pill } from '../src';
@@ -34,38 +36,46 @@ export const Default = () => {
     {
       header: 'First Name',
       accessorKey: 'firstName',
+      footer: (props )=> props.column.id
     },
     {
       header: 'Last Name',
       accessorKey: 'lastName',
+      footer: props => props.column.id,
     },
     {
       header: 'Gender',
       accessorKey: 'gender',
+      footer: props => props.column.id,
     },
     {
       header: 'Age',
       accessorKey: 'age',
+      footer: props => props.column.id,
     },
     {
       header: 'Address',
       accessorKey: 'address',
+      footer: props => props.column.id,
     },
     {
       header: 'City',
       accessorKey: 'city',
+      footer: props => props.column.id,
     },
     {
       header: 'Subscribed',
       accessorKey: 'isSubscribed',
+      footer: props => props.column.id,
     },
     {
       header: 'Birthday',
       accessorKey: 'birthday',
+      footer: props => props.column.id,
     },
   ];
 
-  return <DataTable columns={columns} data={data} />;
+  return <DataTable columns={columns} data={data}/>;
 };
 
 export const CustomCellRendering = () => {
@@ -487,8 +497,8 @@ export const TotalFooterRow = () => {
     headerTotalObj: TotalsDataObj,
     headerId: number | string,
     index: number,
-    keyword: number,
-  ) => {
+    keyword: string,
+  ): any => {
     if (headerTotalObj !== undefined) {
       if (
         (headerTotalObj[headerId] === undefined && headerTotalObj[headerId].value === undefined) ||

--- a/packages/react/stories/DataTable.stories.tsx
+++ b/packages/react/stories/DataTable.stories.tsx
@@ -510,6 +510,12 @@ export const TotalFooterRow = () => {
   };
 
   return (
-    <DataTable enableStickyHeader columns={columns} data={data} enablePagination={false} footerProps={footerObj} />
+    <DataTable
+      enableStickyHeader
+      columns={columns}
+      data={data}
+      enablePagination={false}
+      footerProps={footerObj}
+    />
   );
 };


### PR DESCRIPTION
<!--- We really appreciated your pull request! -->

Closes # <!-- Github issue # here -->

## 📝 Description

Added support for summary footer pinning to bottom

## Screenshots

<img width="1266" alt="image" src="https://github.com/project44/manifest/assets/133108657/1b46060d-4c69-4036-bafb-9e8108eef27b">


## Merge checklist

- [ ] Added/updated tests
- [ ] Added changeset
