### PR TITLE
fix: add endIconClickable and endIconClickable to manage pointer events in textfieldbase

### DIFF
--- a/.changeset/rude-ducks-marry.md
+++ b/.changeset/rude-ducks-marry.md
@@ -1,0 +1,5 @@
+---
+'@project44-manifest/react': minor
+---
+
+fix: added property to manage pointer events of end and start icon

--- a/apps/website/docs/inputs/text-field.mdx
+++ b/apps/website/docs/inputs/text-field.mdx
@@ -42,6 +42,24 @@ function ControlledExample() {
 }
 ```
 
+### Clickable icon
+
+A text area's end and start icon can be clickable. We simply need to pass an icon with click handler. 
+
+```jsx live
+function ControlledExample() {
+  const [value, setValue] = React.useState('Lorem ipsum');
+  const onClick = () => {};
+
+  return (
+    <TextField aria-label="name" onChange={setValue} value={value} endIcon={
+      <IconButton size="small">
+      <Icon icon="search" onClick={onClick} />
+    </IconButton>} />
+  );
+}
+```
+
 ### Disabled State
 
 Set the `isDisabled` prop to prevent a user from inputting text.

--- a/apps/website/docs/inputs/text-field.mdx
+++ b/apps/website/docs/inputs/text-field.mdx
@@ -49,12 +49,12 @@ A text area's end and start icon can be clickable. We simply need to pass an ico
 ```jsx live
 function ControlledExample() {
   const [value, setValue] = React.useState('Lorem ipsum');
-  const onClick = () => {};
+  const onPress = () => {};
 
   return (
     <TextField aria-label="name" onChange={setValue} value={value} endIcon={
-      <IconButton size="small">
-      <Icon icon="search" onClick={onClick} />
+      <IconButton size="small" onPress={onPress} >
+      <Icon icon="search"/>
     </IconButton>} />
   );
 }

--- a/packages/react/src/components/TextFieldBase/TextFieldBase.styles.ts
+++ b/packages/react/src/components/TextFieldBase/TextFieldBase.styles.ts
@@ -32,6 +32,10 @@ export const useStyles = css({
     },
   },
 
+  '.manifest-textfield-base__icon_allow_pointer_events': {
+    pointerEvents: 'auto',
+  },
+
   '.manifest-textfield-base__icon--end': {
     right: 0,
   },

--- a/packages/react/src/components/TextFieldBase/TextFieldBase.styles.ts
+++ b/packages/react/src/components/TextFieldBase/TextFieldBase.styles.ts
@@ -32,10 +32,6 @@ export const useStyles = css({
     },
   },
 
-  '.manifest-textfield-base__icon_allow_pointer_events': {
-    pointerEvents: 'auto',
-  },
-
   '.manifest-textfield-base__icon--end': {
     right: 0,
   },

--- a/packages/react/src/components/TextFieldBase/TextFieldBase.styles.ts
+++ b/packages/react/src/components/TextFieldBase/TextFieldBase.styles.ts
@@ -22,11 +22,11 @@ export const useStyles = css({
     fontSize: '$x-large',
     justifyContent: 'center',
     padding: '$small',
-    pointerEvents: 'none',
+    pointerEvents: 'auto',
     position: 'absolute',
     top: 0,
     zIndex: 2,
-
+    bottom: 0,
     '> .material-icons': {
       fontSize: '$x-large',
     },

--- a/packages/react/src/components/TextFieldBase/TextFieldBase.tsx
+++ b/packages/react/src/components/TextFieldBase/TextFieldBase.tsx
@@ -20,6 +20,10 @@ export interface TextFieldBaseOptions<T extends As = TextFieldBaseElement>
    */
   endIcon?: React.ReactNode;
   /**
+   * Allows pointer events on endIcon
+   */
+  endIconClickable?: boolean;
+  /**
    * Helper text to append to the form control input element.
    */
   helperText?: React.ReactNode;
@@ -66,6 +70,10 @@ export interface TextFieldBaseOptions<T extends As = TextFieldBaseElement>
    */
   startIcon?: React.ReactNode;
   /**
+   * Allows pointer events on start icon
+   */
+  startIconClickable?: boolean;
+  /**
    * Whether the input should display its "valid" or "invalid" visual styling.
    */
   validationState?: ValidationState;
@@ -82,6 +90,7 @@ export const TextFieldBase = createComponent<TextFieldBaseOptions>((props, forwa
     className: classNameProp,
     css,
     endIcon,
+    endIconClickable = false,
     helperText,
     helperTextProps,
     inputProps = {},
@@ -92,6 +101,7 @@ export const TextFieldBase = createComponent<TextFieldBaseOptions>((props, forwa
     labelProps,
     multiline = false,
     startIcon,
+    startIconClickable = false,
     validationState,
   } = props;
 
@@ -136,7 +146,11 @@ export const TextFieldBase = createComponent<TextFieldBaseOptions>((props, forwa
       <div ref={forwardedRef} className="manifest-textfield-base__wrapper">
         {startIcon && (
           <span
-            className={cx('manifest-textfield-base__icon', 'manifest-textfield-base__icon--start')}
+            className={cx(
+              'manifest-textfield-base__icon',
+              'manifest-textfield-base__icon--start',
+              startIconClickable ? 'manifest-textfield-base__icon_allow_pointer_events' : '',
+            )}
           >
             {startIcon}
           </span>
@@ -151,7 +165,12 @@ export const TextFieldBase = createComponent<TextFieldBaseOptions>((props, forwa
 
         {endIcon && (
           <span
-            className={cx('manifest-textfield-base__icon', 'manifest-textfield-base__icon--end')}
+            className={cx(
+              'manifest-textfield-base__icon',
+              'manifest-textfield-base__icon--end',
+              endIconClickable ? 'manifest-textfield-base__icon_allow_pointer_events' : '',
+            )}
+            data-testid="end-icon"
           >
             {endIcon}
           </span>

--- a/packages/react/src/components/TextFieldBase/TextFieldBase.tsx
+++ b/packages/react/src/components/TextFieldBase/TextFieldBase.tsx
@@ -20,10 +20,6 @@ export interface TextFieldBaseOptions<T extends As = TextFieldBaseElement>
    */
   endIcon?: React.ReactNode;
   /**
-   * Allows pointer events on endIcon
-   */
-  endIconClickable?: boolean;
-  /**
    * Helper text to append to the form control input element.
    */
   helperText?: React.ReactNode;
@@ -70,10 +66,6 @@ export interface TextFieldBaseOptions<T extends As = TextFieldBaseElement>
    */
   startIcon?: React.ReactNode;
   /**
-   * Allows pointer events on start icon
-   */
-  startIconClickable?: boolean;
-  /**
    * Whether the input should display its "valid" or "invalid" visual styling.
    */
   validationState?: ValidationState;
@@ -90,7 +82,6 @@ export const TextFieldBase = createComponent<TextFieldBaseOptions>((props, forwa
     className: classNameProp,
     css,
     endIcon,
-    endIconClickable = false,
     helperText,
     helperTextProps,
     inputProps = {},
@@ -101,7 +92,6 @@ export const TextFieldBase = createComponent<TextFieldBaseOptions>((props, forwa
     labelProps,
     multiline = false,
     startIcon,
-    startIconClickable = false,
     validationState,
   } = props;
 
@@ -146,11 +136,7 @@ export const TextFieldBase = createComponent<TextFieldBaseOptions>((props, forwa
       <div ref={forwardedRef} className="manifest-textfield-base__wrapper">
         {startIcon && (
           <span
-            className={cx(
-              'manifest-textfield-base__icon',
-              'manifest-textfield-base__icon--start',
-              startIconClickable ? 'manifest-textfield-base__icon_allow_pointer_events' : '',
-            )}
+            className={cx('manifest-textfield-base__icon', 'manifest-textfield-base__icon--start')}
           >
             {startIcon}
           </span>
@@ -165,12 +151,7 @@ export const TextFieldBase = createComponent<TextFieldBaseOptions>((props, forwa
 
         {endIcon && (
           <span
-            className={cx(
-              'manifest-textfield-base__icon',
-              'manifest-textfield-base__icon--end',
-              endIconClickable ? 'manifest-textfield-base__icon_allow_pointer_events' : '',
-            )}
-            data-testid="end-icon"
+            className={cx('manifest-textfield-base__icon', 'manifest-textfield-base__icon--end')}
           >
             {endIcon}
           </span>

--- a/packages/react/stories/TextField.stories.tsx
+++ b/packages/react/stories/TextField.stories.tsx
@@ -26,13 +26,15 @@ Sizes.decorators = [
 
 export const Icons = Template.bind({});
 
+const onClick = () => {};
+
 Icons.decorators = [
   () => (
     <Flex css={{ gap: '$small' }} orientation="vertical">
       <TextField
         endIcon={
           <IconButton size="small">
-            <Icon icon="search" />
+            <Icon icon="search" onClick={onClick} />
           </IconButton>
         }
         placeholder="Search..."

--- a/packages/react/stories/TextField.stories.tsx
+++ b/packages/react/stories/TextField.stories.tsx
@@ -26,17 +26,21 @@ Sizes.decorators = [
 
 export const Icons = Template.bind({});
 
+const onClick = () => {
+  console.log('Test');
+};
+
 Icons.decorators = [
   () => (
     <Flex css={{ gap: '$small' }} orientation="vertical">
       <TextField
         endIconClickable
-        endIcon={<Icon onClick={() => console.log('Test')} icon="search" />}
+        endIcon={<Icon icon="search" onClick={onClick} />}
         placeholder="Search..."
       />
       <TextField placeholder="Search..." startIcon={<Icon icon="search" />} />
     </Flex>
-  )
+  ),
 ];
 
 export const Label = Template.bind({});

--- a/packages/react/stories/TextField.stories.tsx
+++ b/packages/react/stories/TextField.stories.tsx
@@ -26,9 +26,7 @@ Sizes.decorators = [
 
 export const Icons = Template.bind({});
 
-const onClick = () => {
-  return;
-};
+const onClick = () => {};
 
 Icons.decorators = [
   () => (

--- a/packages/react/stories/TextField.stories.tsx
+++ b/packages/react/stories/TextField.stories.tsx
@@ -26,17 +26,13 @@ Sizes.decorators = [
 
 export const Icons = Template.bind({});
 
-const onClick = () => {
-  console.log('Test');
-};
-
 Icons.decorators = [
   () => (
     <Flex css={{ gap: '$small' }} orientation="vertical">
       <TextField
         endIcon={
           <IconButton size="small">
-            <Icon icon="search" onClick={onClick} />
+            <Icon icon="search" />
           </IconButton>
         }
         placeholder="Search..."

--- a/packages/react/stories/TextField.stories.tsx
+++ b/packages/react/stories/TextField.stories.tsx
@@ -26,7 +26,9 @@ Sizes.decorators = [
 
 export const Icons = Template.bind({});
 
-const onClick = () => {};
+const onClick = () => {
+  return;
+};
 
 Icons.decorators = [
   () => (

--- a/packages/react/stories/TextField.stories.tsx
+++ b/packages/react/stories/TextField.stories.tsx
@@ -29,10 +29,14 @@ export const Icons = Template.bind({});
 Icons.decorators = [
   () => (
     <Flex css={{ gap: '$small' }} orientation="vertical">
-      <TextField endIcon={<Icon icon="search" />} placeholder="Search..." />
+      <TextField
+        endIconClickable
+        endIcon={<Icon onClick={() => console.log('Test')} icon="search" />}
+        placeholder="Search..."
+      />
       <TextField placeholder="Search..." startIcon={<Icon icon="search" />} />
     </Flex>
-  ),
+  )
 ];
 
 export const Label = Template.bind({});

--- a/packages/react/stories/TextField.stories.tsx
+++ b/packages/react/stories/TextField.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { ComponentStory } from '@storybook/react';
-import { Flex, Icon, TextField } from '../src';
+import { Flex, Icon, IconButton, TextField } from '../src';
 
 export default {
   title: 'Components/TextField',
@@ -34,8 +34,11 @@ Icons.decorators = [
   () => (
     <Flex css={{ gap: '$small' }} orientation="vertical">
       <TextField
-        endIconClickable
-        endIcon={<Icon icon="search" onClick={onClick} />}
+        endIcon={
+          <IconButton size="small">
+            <Icon icon="search" onClick={onClick} />
+          </IconButton>
+        }
         placeholder="Search..."
       />
       <TextField placeholder="Search..." startIcon={<Icon icon="search" />} />

--- a/packages/react/tests/TextFieldBase.test.tsx
+++ b/packages/react/tests/TextFieldBase.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Button, Icon, IconButton } from '../src';
 import { TextFieldBase } from '../src/components/TextFieldBase';
 
 describe('@project44-manifest/components - TextFieldBase', () => {
@@ -15,35 +16,54 @@ describe('@project44-manifest/components - TextFieldBase', () => {
     expect(screen.getByRole('textbox')).toHaveAttribute('rows');
   });
 
-  it('pointer event should be allowed', () => {
+  it('end icon should be clickable', () => {
+    const onClick = jest.fn();
     render(
       <TextFieldBase
-        endIconClickable
-        endIcon={<span>end icon</span>}
-        startIcon={<span>start icon</span>}
+        endIcon={
+          <IconButton size="small">
+            <Icon data-testid="end-icon" icon="search" onClick={onClick} />
+          </IconButton>
+        }
       />,
     );
 
-    expect(screen.getByText('end icon')).toBeInTheDocument();
-    expect(screen.getByText('start icon')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('end-icon'));
 
-    expect(
-      screen
-        .getByTestId('end-icon')
-        .classList.contains('manifest-textfield-base__icon_allow_pointer_events'),
-    ).toBeTruthy();
+    expect(onClick).toHaveBeenCalled();
   });
 
-  it('pointer event should be stopped', () => {
-    render(<TextFieldBase endIcon={<span>end icon</span>} startIcon={<span>start icon</span>} />);
+  it('start icon should be clickable', () => {
+    const onClick = jest.fn();
+    render(
+      <TextFieldBase
+        startIcon={
+          <IconButton size="small">
+            <Icon data-testid="start-icon" icon="search" onClick={onClick} />
+          </IconButton>
+        }
+      />,
+    );
 
-    expect(screen.getByText('end icon')).toBeInTheDocument();
-    expect(screen.getByText('start icon')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('start-icon'));
 
-    expect(
-      screen
-        .getByTestId('end-icon')
-        .classList.contains('manifest-textfield-base__icon_allow_pointer_events'),
-    ).toBeFalsy();
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('start icon should not be clickable', () => {
+    const onClick = jest.fn();
+    render(
+      <TextFieldBase
+        startIcon={
+          <Button isDisabled data-testid="start-icon" onPress={onClick}>
+            <span>start icon</span>
+          </Button>
+        }
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('start-icon'));
+
+    expect(onClick).not.toHaveBeenCalled();
   });
 });

--- a/packages/react/tests/TextFieldBase.test.tsx
+++ b/packages/react/tests/TextFieldBase.test.tsx
@@ -30,7 +30,7 @@ describe('@project44-manifest/components - TextFieldBase', () => {
     expect(
       screen
         .getByTestId('end-icon')
-        .classList.contains('.manifest-textfield-base__icon_allow_pointer_events'),
+        .classList.contains('manifest-textfield-base__icon_allow_pointer_events'),
     ).toBeTruthy();
   });
 
@@ -43,7 +43,7 @@ describe('@project44-manifest/components - TextFieldBase', () => {
     expect(
       screen
         .getByTestId('end-icon')
-        .classList.contains('.manifest-textfield-base__icon_allow_pointer_events'),
+        .classList.contains('manifest-textfield-base__icon_allow_pointer_events'),
     ).toBeFalsy();
   });
 });

--- a/packages/react/tests/TextFieldBase.test.tsx
+++ b/packages/react/tests/TextFieldBase.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { TextFieldBase } from '../src/components/TextFieldBase';
 
 describe('@project44-manifest/components - TextFieldBase', () => {
@@ -16,11 +16,10 @@ describe('@project44-manifest/components - TextFieldBase', () => {
   });
 
   it('pointer event should be allowed', () => {
-    const onClick = jest.fn();
     render(
       <TextFieldBase
         endIconClickable
-        endIcon={<span onClick={onClick}>end icon</span>}
+        endIcon={<span>end icon</span>}
         startIcon={<span>start icon</span>}
       />,
     );

--- a/packages/react/tests/TextFieldBase.test.tsx
+++ b/packages/react/tests/TextFieldBase.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { TextFieldBase } from '../src/components/TextFieldBase';
 
 describe('@project44-manifest/components - TextFieldBase', () => {
@@ -13,5 +13,38 @@ describe('@project44-manifest/components - TextFieldBase', () => {
     render(<TextFieldBase multiline />);
 
     expect(screen.getByRole('textbox')).toHaveAttribute('rows');
+  });
+
+  it('pointer event should be allowed', () => {
+    const onClick = jest.fn();
+    render(
+      <TextFieldBase
+        endIconClickable
+        endIcon={<span onClick={onClick}>end icon</span>}
+        startIcon={<span>start icon</span>}
+      />,
+    );
+
+    expect(screen.getByText('end icon')).toBeInTheDocument();
+    expect(screen.getByText('start icon')).toBeInTheDocument();
+
+    expect(
+      screen
+        .getByTestId('end-icon')
+        .classList.contains('.manifest-textfield-base__icon_allow_pointer_events'),
+    ).toBeTruthy();
+  });
+
+  it('pointer event should be stopped', () => {
+    render(<TextFieldBase endIcon={<span>end icon</span>} startIcon={<span>start icon</span>} />);
+
+    expect(screen.getByText('end icon')).toBeInTheDocument();
+    expect(screen.getByText('start icon')).toBeInTheDocument();
+
+    expect(
+      screen
+        .getByTestId('end-icon')
+        .classList.contains('.manifest-textfield-base__icon_allow_pointer_events'),
+    ).toBeFalsy();
   });
 });


### PR DESCRIPTION
<!--- We really appreciated your pull request! -->

Closes #412 

## 📝 Description

Currently due to pointer events none on the span above icon the onClicks are not working on icons unless specified explicitly on icons itself, so we are introducing two new properties to override that behaviour. By default it will still behave the same if you need clicks on icons in text field you can simply use `endIconClickable` and `startIconClickable`.

## Screenshots

> Please provide screenshots for any visual changes

## Merge checklist

- [x] Added/updated tests
- [x] Added changeset
