### PR TITLE
fix: added display names to components for better debugging

### DIFF
--- a/.changeset/neat-ways-turn.md
+++ b/.changeset/neat-ways-turn.md
@@ -1,0 +1,5 @@
+---
+'@project44-manifest/react': minor
+---
+
+Added displayName to components

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -4,7 +4,6 @@
 		"eslint --fix --max-warnings 0"
 	],
 	"**/*.{md,mdx,yml,json}": [
-		"prettier --write",
-		"eslint --fix --max-warnings 0"
+		"prettier --write"
 	]
 }

--- a/packages/react/src/components/CSSBaseline/CSSBaseline.tsx
+++ b/packages/react/src/components/CSSBaseline/CSSBaseline.tsx
@@ -10,3 +10,5 @@ export const CssBaseline = React.memo<React.PropsWithChildren<unknown>>((props) 
   // eslint-disable-next-line react/jsx-no-useless-fragment
   return <>{children}</>;
 });
+
+CssBaseline.displayName = 'CssBaseline';

--- a/packages/react/src/components/Calendar/Calendar.tsx
+++ b/packages/react/src/components/Calendar/Calendar.tsx
@@ -51,3 +51,5 @@ export const Calendar = createComponent<CalendarOptions>((props, forwardedRef) =
     </Comp>
   );
 });
+
+Calendar.displayName = 'Calendar';

--- a/packages/react/src/components/CalendarCell/CalendarCell.tsx
+++ b/packages/react/src/components/CalendarCell/CalendarCell.tsx
@@ -95,3 +95,5 @@ export function CalendarCell(props: CalendarCellProps) {
     </td>
   );
 }
+
+CalendarCell.displayName = 'CalendarCell';

--- a/packages/react/src/components/CalendarHeader/CalendarHeader.tsx
+++ b/packages/react/src/components/CalendarHeader/CalendarHeader.tsx
@@ -65,3 +65,5 @@ export function CalendarHeader(props: CalendarHeaderProps) {
     </div>
   );
 }
+
+CalendarHeader.displayName = 'CalendarHeader';

--- a/packages/react/src/components/CalendarRange/CalendarRange.tsx
+++ b/packages/react/src/components/CalendarRange/CalendarRange.tsx
@@ -125,3 +125,5 @@ export const CalendarRange = createComponent<CalendarRangeOptions>((props, forwa
     </Comp>
   );
 });
+
+CalendarRange.displayName = 'CalendarRange';

--- a/packages/react/src/components/CalendarRanges/CalendarRanges.tsx
+++ b/packages/react/src/components/CalendarRanges/CalendarRanges.tsx
@@ -64,3 +64,5 @@ export function CalendarRanges(props: CalendarRangesProps) {
     </div>
   );
 }
+
+CalendarRanges.displayName = 'CalendarRanges';

--- a/packages/react/src/components/CalendarTable/CalendarTable.tsx
+++ b/packages/react/src/components/CalendarTable/CalendarTable.tsx
@@ -72,3 +72,5 @@ export function CalendarTable(props: CalendarTableProps) {
     </div>
   );
 }
+
+CalendarTable.displayName = 'CalendarTable';

--- a/packages/react/src/components/Card/Card.tsx
+++ b/packages/react/src/components/Card/Card.tsx
@@ -15,3 +15,5 @@ export const Card = React.forwardRef((props, forwardedRef) => {
     </StyledCard>
   );
 }) as ForwardRefComponent<CardElement, CardProps>;
+
+Card.displayName = 'Card';

--- a/packages/react/src/components/CardBody/CardBody.tsx
+++ b/packages/react/src/components/CardBody/CardBody.tsx
@@ -15,3 +15,5 @@ export const CardBody = React.forwardRef((props, forwardedRef) => {
     </StyledCardBody>
   );
 }) as ForwardRefComponent<CardBodyElement, CardBodyProps>;
+
+CardBody.displayName = 'CardBody';

--- a/packages/react/src/components/CardFooter/CardFooter.tsx
+++ b/packages/react/src/components/CardFooter/CardFooter.tsx
@@ -15,3 +15,5 @@ export const CardFooter = React.forwardRef((props, forwardedRef) => {
     </StyledCardFooter>
   );
 }) as ForwardRefComponent<CardFooterElement, CardFooterProps>;
+
+CardFooter.displayName = 'CardFooter';

--- a/packages/react/src/components/CardHeader/CardHeader.tsx
+++ b/packages/react/src/components/CardHeader/CardHeader.tsx
@@ -15,3 +15,5 @@ export const CardHeader = React.forwardRef((props, forwardedRef) => {
     </StyledCardHeader>
   );
 }) as ForwardRefComponent<CardHeaderElement, CardHeaderProps>;
+
+CardHeader.displayName = 'CardHeader';

--- a/packages/react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.tsx
@@ -79,3 +79,5 @@ export const Checkbox = createComponent<CheckboxOptions>((props, forwardedRef) =
     </Comp>
   );
 });
+
+Checkbox.displayName = 'Checkbox';

--- a/packages/react/src/components/Collapse/Collapse.tsx
+++ b/packages/react/src/components/Collapse/Collapse.tsx
@@ -98,3 +98,5 @@ export const Collapse = React.forwardRef<HTMLElement, CollapseProps>((props, for
     </Transition>
   );
 });
+
+Collapse.displayName = 'Collapse';

--- a/packages/react/src/components/Combobox/Combobox.tsx
+++ b/packages/react/src/components/Combobox/Combobox.tsx
@@ -253,3 +253,5 @@ export const Combobox = createComponent<ComboboxOptions>((props, forwardedRef) =
     </FormControl>
   );
 });
+
+Combobox.displayName = 'Combobox';

--- a/packages/react/src/components/DataTable/DataTable.tsx
+++ b/packages/react/src/components/DataTable/DataTable.tsx
@@ -167,5 +167,4 @@ export function DataTable<TData extends RowData>(props: DataTableProps<TData>) {
     </StyledDataTable>
   );
 }
-
 export const createDataTableColumnHelper = createColumnHelper;

--- a/packages/react/src/components/DataTable/components/DataTableBody/DataTableBody.tsx
+++ b/packages/react/src/components/DataTable/components/DataTableBody/DataTableBody.tsx
@@ -17,3 +17,5 @@ export function DataTableBody<TData extends RowData>(props: DataTableBodyProps<T
     </tbody>
   );
 }
+
+DataTableBody.displayName = 'DataTableBody';

--- a/packages/react/src/components/DataTable/components/DataTableCell/DataTableCell.tsx
+++ b/packages/react/src/components/DataTable/components/DataTableCell/DataTableCell.tsx
@@ -31,3 +31,5 @@ export function DataTableCell<TData extends RowData, TVaue>(
     </td>
   );
 }
+
+DataTableCell.displayName = 'DataTableCell';

--- a/packages/react/src/components/DataTable/components/DataTableCheckbox/DataTableCheckbox.tsx
+++ b/packages/react/src/components/DataTable/components/DataTableCheckbox/DataTableCheckbox.tsx
@@ -47,3 +47,5 @@ export function DataTableCheckbox<TData extends RowData>(props: DataTableCheckbo
     </div>
   );
 }
+
+DataTableCheckbox.displayName = 'DataTableCheckbox';

--- a/packages/react/src/components/DataTable/components/DataTableColumn/DataTableColumn.tsx
+++ b/packages/react/src/components/DataTable/components/DataTableColumn/DataTableColumn.tsx
@@ -43,3 +43,5 @@ export function DataTableColumn<TData extends RowData, TVaue>(
     </th>
   );
 }
+
+DataTableColumn.displayName = 'DataTableColumn';

--- a/packages/react/src/components/DataTable/components/DataTableExpandAllButton/DataTableExpandAllButton.tsx
+++ b/packages/react/src/components/DataTable/components/DataTableExpandAllButton/DataTableExpandAllButton.tsx
@@ -46,3 +46,5 @@ export function DataTableExpandAllButton<TData extends RowData>(
     </IconButton>
   );
 }
+
+DataTableExpandAllButton.displayName = 'DataTableExpandAllButton';

--- a/packages/react/src/components/DataTable/components/DataTableExpandButton/DataTableExpandButton.tsx
+++ b/packages/react/src/components/DataTable/components/DataTableExpandButton/DataTableExpandButton.tsx
@@ -45,3 +45,5 @@ export function DataTableExpandButton<TData extends RowData>(
     </IconButton>
   );
 }
+
+DataTableExpandButton.displayName = 'DataTableExpandButton';

--- a/packages/react/src/components/DataTable/components/DataTableFooter/DataTableFooter.tsx
+++ b/packages/react/src/components/DataTable/components/DataTableFooter/DataTableFooter.tsx
@@ -28,3 +28,5 @@ export function DataTableFooter<TData extends RowData>(props: DataTableFooterPro
     </tfoot>
   );
 }
+
+DataTableFooter.displayName = 'DataTableFooter';

--- a/packages/react/src/components/DataTable/components/DataTableFooterColumn/DataTableFooterColumn.tsx
+++ b/packages/react/src/components/DataTable/components/DataTableFooterColumn/DataTableFooterColumn.tsx
@@ -35,3 +35,5 @@ export function DataTableFooterColumn<TData extends RowData, TVaue>(
     </th>
   );
 }
+
+DataTableFooterColumn.displayName = 'DataTableFooterColumn';

--- a/packages/react/src/components/DataTable/components/DataTableHeader/DataTableHeader.tsx
+++ b/packages/react/src/components/DataTable/components/DataTableHeader/DataTableHeader.tsx
@@ -22,3 +22,5 @@ export function DataTableHeader<TData extends RowData>(props: DataTableHeaderPro
     </thead>
   );
 }
+
+DataTableHeader.displayName = 'DataTableHeader';

--- a/packages/react/src/components/DataTable/components/DataTablePagination/DataTablePagination.tsx
+++ b/packages/react/src/components/DataTable/components/DataTablePagination/DataTablePagination.tsx
@@ -36,3 +36,5 @@ export function DataTablePagination<TData extends RowData>(props: DataTablePagin
     </div>
   );
 }
+
+DataTablePagination.displayName = 'DataTablePagination';

--- a/packages/react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.tsx
@@ -224,3 +224,5 @@ export const DatePicker = createComponent<DatePickerOptions>((props, forwardedRe
     </FormControl>
   );
 });
+
+DatePicker.displayName = 'DatePicker';

--- a/packages/react/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/packages/react/src/components/DateRangePicker/DateRangePicker.tsx
@@ -266,3 +266,5 @@ export const DateRangePicker = createComponent<DateRangePickerOptions>((props, f
     </FormControl>
   );
 });
+
+DateRangePicker.displayName = 'DateRangePicker';

--- a/packages/react/src/components/Dialog/Dialog.tsx
+++ b/packages/react/src/components/Dialog/Dialog.tsx
@@ -58,6 +58,8 @@ const DialogImpl = React.forwardRef((props, forwardedRef) => {
   );
 }) as ForwardRefComponent<DialogElement, DialogProps>;
 
+DialogImpl.displayName = 'DialogImpl';
+
 export const Dialog = React.forwardRef((props, forwardedRef) => {
   const {
     isDismissable = true,
@@ -78,3 +80,5 @@ export const Dialog = React.forwardRef((props, forwardedRef) => {
     </Modal>
   );
 }) as ForwardRefComponent<DialogElement, DialogProps>;
+
+Dialog.displayName = 'Dialog';

--- a/packages/react/src/components/DialogContent/DialogContent.tsx
+++ b/packages/react/src/components/DialogContent/DialogContent.tsx
@@ -15,3 +15,5 @@ export const DialogContent = React.forwardRef((props, forwardedRef) => {
     </StyledDialogContent>
   );
 }) as ForwardRefComponent<DialogContentElement, DialogContentProps>;
+
+DialogContent.displayName = 'DialogContent';

--- a/packages/react/src/components/DialogFooter/DialogFooter.tsx
+++ b/packages/react/src/components/DialogFooter/DialogFooter.tsx
@@ -18,3 +18,5 @@ export const DialogFooter = React.forwardRef((props, forwardedRef) => {
     </StyledDialogFooter>
   );
 }) as ForwardRefComponent<DialogFooterElement, DialogFooterProps>;
+
+DialogFooter.displayName = 'DialogFooter';

--- a/packages/react/src/components/DialogHeader/DialogHeader.tsx
+++ b/packages/react/src/components/DialogHeader/DialogHeader.tsx
@@ -46,3 +46,5 @@ export const DialogHeader = React.forwardRef((props, forwardedRef) => {
     </StyledDialogHeader>
   );
 }) as ForwardRefComponent<DialogHeaderElement, DialogHeaderProps>;
+
+DialogHeader.displayName = 'DialogHeader';

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -86,3 +86,5 @@ export function Dropdown(props: DropdownProps) {
     </DropdownProvider>
   );
 }
+
+Dropdown.displayName = 'Dropdown';

--- a/packages/react/src/components/DropdownItem/DropdownItem.tsx
+++ b/packages/react/src/components/DropdownItem/DropdownItem.tsx
@@ -99,3 +99,5 @@ export const DropdownItem = React.forwardRef((props, forwardedRef) => {
     </StyledDropdownItem>
   );
 }) as ForwardRefComponent<DropdownItemElement, DropdownItemOptions>;
+
+DropdownItem.displayName = 'DropdownItem';

--- a/packages/react/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/packages/react/src/components/DropdownMenu/DropdownMenu.tsx
@@ -50,3 +50,5 @@ export const DropdownMenu = React.forwardRef((props, forwardedRef) => {
     </StyledDropdownMenu>
   );
 }) as ForwardRefComponent<DropdownMenuElement, DropdownMenuProps>;
+
+DropdownMenu.displayName = 'DropdownMenu';

--- a/packages/react/src/components/DropdownSection/DropdownSection.tsx
+++ b/packages/react/src/components/DropdownSection/DropdownSection.tsx
@@ -55,3 +55,5 @@ export const DropdownSection = React.forwardRef((props, forwardedRef) => {
     </>
   );
 }) as ForwardRefComponent<DropdownSectionElement, DropdownSectionOptions>;
+
+DropdownSection.displayName = 'DropdownSection';

--- a/packages/react/src/components/Fade/Fade.tsx
+++ b/packages/react/src/components/Fade/Fade.tsx
@@ -73,3 +73,5 @@ export const Fade = React.forwardRef<HTMLElement, FadeProps>((props, forwardedRe
     </Transition>
   );
 });
+
+Fade.displayName = 'Fade';

--- a/packages/react/src/components/FormControl/FormControl.tsx
+++ b/packages/react/src/components/FormControl/FormControl.tsx
@@ -99,3 +99,5 @@ export const FormControl = createComponent<FormControlOptions>((props, forwarded
     </div>
   );
 });
+
+FormControl.displayName = 'FormControl';

--- a/packages/react/src/components/HiddenMultiSelect/HiddenMultiSelect.tsx
+++ b/packages/react/src/components/HiddenMultiSelect/HiddenMultiSelect.tsx
@@ -53,3 +53,5 @@ export function HiddenMultiSelect<T>(props: HiddenMultiSelectProps<T>) {
 
   return null;
 }
+
+HiddenMultiSelect.displayName = 'HiddenMultiSelect';

--- a/packages/react/src/components/Icon/Icon.tsx
+++ b/packages/react/src/components/Icon/Icon.tsx
@@ -29,3 +29,5 @@ export const Icon = createComponent<IconOptions>((props, forwardedRef) => {
     </Comp>
   );
 });
+
+Icon.displayName = 'Icon';

--- a/packages/react/src/components/Link/Link.tsx
+++ b/packages/react/src/components/Link/Link.tsx
@@ -17,3 +17,4 @@ export const Link = React.forwardRef((props, forwardedRef) => {
 }) as ForwardRefComponent<LinkElement, LinkProps>;
 
 Link.toString = () => '.manifest-link';
+Link.displayName = 'Link';

--- a/packages/react/src/components/ListBox/ListBox.tsx
+++ b/packages/react/src/components/ListBox/ListBox.tsx
@@ -13,3 +13,5 @@ export const ListBox = createComponent<ListBoxOptions>((props, forwardedRef) => 
 
   return <ListBoxBase {...props} ref={forwardedRef} state={state} />;
 });
+
+ListBox.displayName = 'ListBox';

--- a/packages/react/src/components/ListBoxBase/ListBoxBase.tsx
+++ b/packages/react/src/components/ListBoxBase/ListBoxBase.tsx
@@ -81,3 +81,5 @@ export const ListBoxBase = createComponent<ListBoxBaseOptions>((props, forwarded
     </ListBoxContext.Provider>
   );
 });
+
+ListBoxBase.displayName = 'ListBoxBase';

--- a/packages/react/src/components/ListBoxItem/ListBoxItem.tsx
+++ b/packages/react/src/components/ListBoxItem/ListBoxItem.tsx
@@ -111,3 +111,5 @@ export const ListBoxItem = createComponent<ListBoxItemOptions>((props, forwarded
     </Comp>
   );
 });
+
+ListBoxItem.displayName = 'ListBoxItem';

--- a/packages/react/src/components/ListBoxSection/ListBoxSection.tsx
+++ b/packages/react/src/components/ListBoxSection/ListBoxSection.tsx
@@ -67,3 +67,5 @@ export const ListBoxSection = createComponent<ListBoxSectionOptions>((props, for
     </>
   );
 });
+
+ListBoxSection.displayName = 'ListBoxSection';

--- a/packages/react/src/components/LocalNavigation/LocalNavigation.tsx
+++ b/packages/react/src/components/LocalNavigation/LocalNavigation.tsx
@@ -53,3 +53,5 @@ export const LocalNavigation = React.forwardRef((props, forwardedRef) => {
     </StyledNavigation>
   );
 }) as ForwardRefComponent<'div', LocalNavigationProps>;
+
+LocalNavigation.displayName = 'LocalNavigation';

--- a/packages/react/src/components/LocalNavigation/components/LocalNavigationDropdownItem/LocalNavigationDropdownItem.tsx
+++ b/packages/react/src/components/LocalNavigation/components/LocalNavigationDropdownItem/LocalNavigationDropdownItem.tsx
@@ -63,3 +63,5 @@ export const LocalNavigationDropdownItem = React.forwardRef((props, forwardedRef
     </Dropdown>
   );
 }) as ForwardRefComponent<'button', LocalNavigationDropdownItemProps>;
+
+LocalNavigationDropdownItem.displayName = 'LocalNavigationDropdownItem';

--- a/packages/react/src/components/LocalNavigation/components/LocalNavigationItem/LocalNavigationItem.tsx
+++ b/packages/react/src/components/LocalNavigation/components/LocalNavigationItem/LocalNavigationItem.tsx
@@ -72,3 +72,5 @@ export const LocalNavigationItem = React.forwardRef((props, forwardedRef) => {
     </StyledItem>
   );
 }) as ForwardRefComponent<'button', LocalNavigationItemProps>;
+
+LocalNavigationItem.displayName = 'LocalNavigationItem';

--- a/packages/react/src/components/Menu/Menu.tsx
+++ b/packages/react/src/components/Menu/Menu.tsx
@@ -15,3 +15,5 @@ export const Menu = React.forwardRef((props, forwardedRef) => {
     </StyledMenu>
   );
 }) as ForwardRefComponent<MenuElement, MenuProps>;
+
+Menu.displayName = 'Menu';

--- a/packages/react/src/components/MenuGroup/MenuGroup.tsx
+++ b/packages/react/src/components/MenuGroup/MenuGroup.tsx
@@ -58,3 +58,5 @@ export const MenuGroup = React.forwardRef((props, forwardedRef) => {
     </StyledMenuGroup>
   );
 }) as ForwardRefComponent<MenuGroupElement, MenuGroupProps>;
+
+MenuGroup.displayName = 'MenuGroup';

--- a/packages/react/src/components/MenuItem/MenuItem.tsx
+++ b/packages/react/src/components/MenuItem/MenuItem.tsx
@@ -58,3 +58,5 @@ export const MenuItem = React.forwardRef((props, forwardedRef) => {
     </StyledMenuItem>
   );
 }) as ForwardRefComponent<MenuItemElement, MenuItemProps>;
+
+MenuItem.displayName = 'MenuItem';

--- a/packages/react/src/components/Modal/Modal.tsx
+++ b/packages/react/src/components/Modal/Modal.tsx
@@ -67,6 +67,8 @@ const ModalImpl = React.forwardRef((props, forwardedRef) => {
   );
 }) as ForwardRefComponent<ModalElement, ModalProps>;
 
+ModalImpl.displayName = 'ModalImpl';
+
 export const Modal = React.forwardRef((props, forwardedRef) => {
   const { isOpen, ...other } = props;
 
@@ -76,3 +78,4 @@ export const Modal = React.forwardRef((props, forwardedRef) => {
     </Overlay>
   );
 }) as ForwardRefComponent<ModalElement, ModalProps>;
+Modal.displayName = 'Modal';

--- a/packages/react/src/components/MultiCombobox/MultiCombobox.tsx
+++ b/packages/react/src/components/MultiCombobox/MultiCombobox.tsx
@@ -241,3 +241,5 @@ export const MultiCombobox = createComponent<MultiComboboxOptions>((props, forwa
     </FormControl>
   );
 });
+
+MultiCombobox.displayName = 'MultiCombobox';

--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -236,3 +236,5 @@ export const MultiSelect = createComponent<MultiSelectOptions>((props, forwarded
     </FormControl>
   );
 });
+
+MultiSelect.displayName = 'MultiSelect';

--- a/packages/react/src/components/NumberField/NumberField.tsx
+++ b/packages/react/src/components/NumberField/NumberField.tsx
@@ -94,3 +94,5 @@ export const NumberField = createComponent<NumberFieldOptions>((props, forwarded
     />
   );
 });
+
+NumberField.displayName = 'NumberField';

--- a/packages/react/src/components/NumberFieldBase/NumberFieldBase.tsx
+++ b/packages/react/src/components/NumberFieldBase/NumberFieldBase.tsx
@@ -122,3 +122,5 @@ export const NumberFieldBase = createComponent<NumberFieldBaseOptions>((props, f
     </FormControl>
   );
 });
+
+NumberFieldBase.displayName = 'NumberFieldBase';

--- a/packages/react/src/components/Overlay/Overlay.tsx
+++ b/packages/react/src/components/Overlay/Overlay.tsx
@@ -13,3 +13,5 @@ export function Overlay(props: OverlayProps) {
     </ReactAriaOverlay>
   );
 }
+
+Overlay.displayName = 'Overlay';

--- a/packages/react/src/components/Pagination/Pagination.tsx
+++ b/packages/react/src/components/Pagination/Pagination.tsx
@@ -162,3 +162,5 @@ export const Pagination = React.forwardRef((props, forwardedRef) => {
     </StyledPagination>
   );
 }) as ForwardRefComponent<PaginationElement, PaginationProps>;
+
+Pagination.displayName = 'Pagination';

--- a/packages/react/src/components/PaginationItem/PaginationItem.tsx
+++ b/packages/react/src/components/PaginationItem/PaginationItem.tsx
@@ -51,3 +51,5 @@ export const PaginationItem = React.forwardRef((props, forwardedRef) => {
     </StyledPaginationItem>
   );
 }) as ForwardRefComponent<PaginationItemElement, PaginationItemProps>;
+
+PaginationItem.displayName = 'PaginationItem';

--- a/packages/react/src/components/Pill/Pill.tsx
+++ b/packages/react/src/components/Pill/Pill.tsx
@@ -98,3 +98,5 @@ export const Pill = createComponent<PillOptions>((props, forwaredRef) => {
     </Comp>
   );
 });
+
+Pill.displayName = 'Pill';

--- a/packages/react/src/components/Popover/Popover.tsx
+++ b/packages/react/src/components/Popover/Popover.tsx
@@ -57,3 +57,5 @@ export const Popover = React.forwardRef((props, forwardedRef) => {
     </FocusScope>
   );
 }) as ForwardRefComponent<PopoverElement, PopoverProps>;
+
+Popover.displayName = 'Popover';

--- a/packages/react/src/components/Portal/Portal.tsx
+++ b/packages/react/src/components/Portal/Portal.tsx
@@ -14,3 +14,5 @@ export function Portal(props: PortalProps) {
 
   return container ? ReactDom.createPortal(children, container) : container;
 }
+
+Portal.displayName = 'Portal';

--- a/packages/react/src/components/Provider/Provider.tsx
+++ b/packages/react/src/components/Provider/Provider.tsx
@@ -31,6 +31,8 @@ const ProviderImpl = React.forwardRef((props, forwardedRef) => {
   );
 }) as ForwardRefComponent<ProviderElement, ProviderProps>;
 
+ProviderImpl.displayName = 'ProviderImpl';
+
 export const Provider = React.forwardRef((props, forwardedRef) => {
   const { locale: prevLocale } = useLocale();
 
@@ -47,3 +49,5 @@ export const Provider = React.forwardRef((props, forwardedRef) => {
     </I18nProvider>
   );
 }) as ForwardRefComponent<ProviderElement, ProviderProps>;
+
+Provider.displayName = 'Provider';

--- a/packages/react/src/components/Radio/Radio.tsx
+++ b/packages/react/src/components/Radio/Radio.tsx
@@ -69,3 +69,5 @@ export const Radio = createComponent<RadioOptions>((props, forwardedRef) => {
     </Comp>
   );
 });
+
+Radio.displayName = 'Radio';

--- a/packages/react/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/react/src/components/RadioGroup/RadioGroup.tsx
@@ -52,3 +52,5 @@ export const RadioGroup = createComponent<RadioGroupOptions>((props, forwardedRe
     </Comp>
   );
 });
+
+RadioGroup.displayName = 'RadioGroup';

--- a/packages/react/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/react/src/components/SegmentedControl/SegmentedControl.tsx
@@ -40,3 +40,5 @@ export const SegmentedControl = React.forwardRef((props, forwardedRef) => {
     </SegmentedControlProvider>
   );
 }) as ForwardRefComponent<'div', SegmentedControlProps>;
+
+SegmentedControl.displayName = 'SegmentedControl';

--- a/packages/react/src/components/SegmentedControl/components/Segment/Segment.tsx
+++ b/packages/react/src/components/SegmentedControl/components/Segment/Segment.tsx
@@ -74,3 +74,5 @@ export const Segment = React.forwardRef((props, forwardedRef) => {
     </StyledSegment>
   );
 }) as ForwardRefComponent<'input', SegmentProps>;
+
+Segment.displayName = 'Segment';

--- a/packages/react/src/components/Select/Select.tsx
+++ b/packages/react/src/components/Select/Select.tsx
@@ -226,3 +226,5 @@ export const Select = createComponent<SelectOptions>((props, forwardedRef) => {
     </FormControl>
   );
 });
+
+Select.displayName = 'Select';

--- a/packages/react/src/components/Separator/Separator.tsx
+++ b/packages/react/src/components/Separator/Separator.tsx
@@ -37,3 +37,5 @@ export const Separator = createComponent<SeparatorOptions>((props, forwardedRef)
 
   return <Comp {...mergeProps(separatorProps, other)} ref={forwardedRef} className={classes} />;
 });
+
+Separator.displayName = 'Separator';

--- a/packages/react/src/components/SideNavigation/SideNavigation.tsx
+++ b/packages/react/src/components/SideNavigation/SideNavigation.tsx
@@ -64,3 +64,5 @@ export const SideNavigation = React.forwardRef((props, forwardedRef) => {
     </NavigationProvider>
   );
 }) as ForwardRefComponent<NavigationElement, NavigationProps>;
+
+SideNavigation.displayName = 'SideNavigation';

--- a/packages/react/src/components/SideNavigationContent/SideNavigationContent.tsx
+++ b/packages/react/src/components/SideNavigationContent/SideNavigationContent.tsx
@@ -24,3 +24,5 @@ export const SideNavigationContent = React.forwardRef((props, forwardedRef) => {
     </StyledSideNavigationContent>
   );
 }) as ForwardRefComponent<SideNavigationContentElement, SideNavigationContentProps>;
+
+SideNavigationContent.displayName = 'SideNavigationContent';

--- a/packages/react/src/components/SideNavigationFooter/SideNavigationFooter.tsx
+++ b/packages/react/src/components/SideNavigationFooter/SideNavigationFooter.tsx
@@ -58,3 +58,5 @@ export const SideNavigationFooter = React.forwardRef((props, forwardedRef) => {
     </StyledSideNavigationFooter>
   );
 }) as ForwardRefComponent<SideNavigationFooterElement, SideNavigationFooterProps>;
+
+SideNavigationFooter.displayName = 'SideNavigationFooter';

--- a/packages/react/src/components/SideNavigationFooterMenu/SideNavigationFooterMenu.tsx
+++ b/packages/react/src/components/SideNavigationFooterMenu/SideNavigationFooterMenu.tsx
@@ -56,3 +56,5 @@ export const SideNavigationFooterMenu = React.forwardRef((props, forwardedRef) =
     </Dropdown>
   );
 }) as ForwardRefComponent<SideNavigationFooterMenuElement, SideNavigationFooterMenuProps>;
+
+SideNavigationFooterMenu.displayName = 'SideNavigationFooterMenu';

--- a/packages/react/src/components/SideNavigationHeader/SideNavigationHeader.tsx
+++ b/packages/react/src/components/SideNavigationHeader/SideNavigationHeader.tsx
@@ -51,3 +51,4 @@ export const SideNavigationHeader = React.forwardRef((props, forwardedRef) => {
     </StyledSideNavigationHeader>
   );
 }) as ForwardRefComponent<SideNavigationHeaderElement, SideNavigationHeaderProps>;
+SideNavigationHeader.displayName = 'SideNavigationHeader';

--- a/packages/react/src/components/SideNavigationMenu/SideNavigationMenu.tsx
+++ b/packages/react/src/components/SideNavigationMenu/SideNavigationMenu.tsx
@@ -14,3 +14,5 @@ export const SideNavigationMenu = React.forwardRef((props, forwardedRef) => {
 
   return <Menu {...other} ref={forwardedRef} className={className} />;
 }) as ForwardRefComponent<SideNavigationMenuElement, SideNavigationMenuProps>;
+
+SideNavigationMenu.displayName = 'SideNavigationMenu';

--- a/packages/react/src/components/SideNavigationMenuGroup/SideNavigationMenuGroup.tsx
+++ b/packages/react/src/components/SideNavigationMenuGroup/SideNavigationMenuGroup.tsx
@@ -25,3 +25,5 @@ export const SideNavigationMenuGroup = React.forwardRef((props, forwardedRef) =>
     />
   );
 }) as ForwardRefComponent<SideNavigationMenuGroupElement, SideNavigationMenuGroupProps>;
+
+SideNavigationMenuGroup.displayName = 'SideNavigationMenuGroup';

--- a/packages/react/src/components/SideNavigationMenuItem/SideNavigationMenuItem.tsx
+++ b/packages/react/src/components/SideNavigationMenuItem/SideNavigationMenuItem.tsx
@@ -17,3 +17,5 @@ export const SideNavigationMenuItem = React.forwardRef((props, forwardedRef) => 
 
   return <StyledMenuItem {...other} ref={forwardedRef} className={className} isOpen={isOpen} />;
 }) as ForwardRefComponent<SideNavigationMenuItemElement, SideNavigationMenuItemProps>;
+
+SideNavigationMenuItem.displayName = 'SideNavigationMenuItem';

--- a/packages/react/src/components/Skeleton/Skeleton.tsx
+++ b/packages/react/src/components/Skeleton/Skeleton.tsx
@@ -13,3 +13,5 @@ export function Skeleton(props: SkeletonProps) {
     </StyledSkeleton>
   );
 }
+
+Skeleton.displayName = 'Skeleton';

--- a/packages/react/src/components/Spinner/Spinner.tsx
+++ b/packages/react/src/components/Spinner/Spinner.tsx
@@ -20,3 +20,5 @@ export const Spinner = React.forwardRef((props, forwardedRef) => {
     />
   );
 }) as ForwardRefComponent<SpinnerElement, SpinnerProps>;
+
+Spinner.displayName = 'Spinner';

--- a/packages/react/src/components/Switch/Switch.tsx
+++ b/packages/react/src/components/Switch/Switch.tsx
@@ -71,3 +71,5 @@ export const Switch = createComponent<SwitchOptions>((props, forwardedRef) => {
     </Comp>
   );
 });
+
+Switch.displayName = 'Switch';

--- a/packages/react/src/components/Table/Table.tsx
+++ b/packages/react/src/components/Table/Table.tsx
@@ -31,3 +31,5 @@ export const Table = React.forwardRef((props, forwardedRef) => {
     </StyledTable>
   );
 }) as ForwardRefComponent<TableElement, TableProps>;
+
+Table.displayName = 'Table';

--- a/packages/react/src/components/TableBody/TableBody.tsx
+++ b/packages/react/src/components/TableBody/TableBody.tsx
@@ -15,3 +15,5 @@ export const TableBody = React.forwardRef((props, forwardedRef) => {
     </StyledTableBody>
   );
 }) as ForwardRefComponent<TableBodyElement, TableBodyProps>;
+
+TableBody.displayName = 'TableBody';

--- a/packages/react/src/components/TableCell/TableCell.tsx
+++ b/packages/react/src/components/TableCell/TableCell.tsx
@@ -54,3 +54,5 @@ export const TableCell = React.forwardRef((props, forwardedRef) => {
     </StyledTableCell>
   );
 }) as ForwardRefComponent<TableCellElement, TableCellProps>;
+
+TableCell.displayName = 'TableCell';

--- a/packages/react/src/components/TableColumn/TableColumn.tsx
+++ b/packages/react/src/components/TableColumn/TableColumn.tsx
@@ -53,3 +53,5 @@ export const TableColumn = React.forwardRef((props, forwardedRef) => {
     </StyledTableColumn>
   );
 }) as ForwardRefComponent<TableColumnElement, TableColumnProps>;
+
+TableColumn.displayName = 'TableColumn';

--- a/packages/react/src/components/TableFooter/TableFooter.tsx
+++ b/packages/react/src/components/TableFooter/TableFooter.tsx
@@ -15,3 +15,5 @@ export const TableFooter = React.forwardRef((props, forwardedRef) => {
     </StyledTableFooter>
   );
 }) as ForwardRefComponent<TableFooterElement, TableFooterProps>;
+
+TableFooter.displayName = 'TableFooter';

--- a/packages/react/src/components/TableHeader/TableHeader.tsx
+++ b/packages/react/src/components/TableHeader/TableHeader.tsx
@@ -15,3 +15,5 @@ export const TableHeader = React.forwardRef((props, forwardedRef) => {
     </StyledTableHeader>
   );
 }) as ForwardRefComponent<TableHeaderElement, TableHeaderProps>;
+
+TableHeader.displayName = 'TableHeader';

--- a/packages/react/src/components/TableRow/TableRow.tsx
+++ b/packages/react/src/components/TableRow/TableRow.tsx
@@ -44,3 +44,5 @@ export const TableRow = React.forwardRef((props, forwardedRef) => {
     </StyledTableRow>
   );
 }) as ForwardRefComponent<TableRowElement, TableRowProps>;
+
+TableRow.displayName = 'TableRow';

--- a/packages/react/src/components/Tag/Tag.tsx
+++ b/packages/react/src/components/Tag/Tag.tsx
@@ -159,3 +159,5 @@ export const Tag = createComponent<TagOptions>((props, forwardedRef) => {
     </Comp>
   );
 });
+
+Tag.displayName = 'Tag';

--- a/packages/react/src/components/TextArea/TextArea.tsx
+++ b/packages/react/src/components/TextArea/TextArea.tsx
@@ -89,3 +89,5 @@ export const TextArea = createComponent<TextAreaOptions>((props, forwardedRef) =
     />
   );
 });
+
+TextArea.displayName = 'TextArea';

--- a/packages/react/src/components/TextField/TextField.tsx
+++ b/packages/react/src/components/TextField/TextField.tsx
@@ -74,3 +74,5 @@ export const TextField = createComponent<TextFieldOptions>((props, forwardedRef)
     />
   );
 });
+
+TextField.displayName = 'TextField';

--- a/packages/react/src/components/TextFieldBase/TextFieldBase.tsx
+++ b/packages/react/src/components/TextFieldBase/TextFieldBase.tsx
@@ -160,3 +160,5 @@ export const TextFieldBase = createComponent<TextFieldBaseOptions>((props, forwa
     </FormControl>
   );
 });
+
+TextFieldBase.displayName = 'TextFieldBase';

--- a/packages/react/src/components/Toast/Toast.tsx
+++ b/packages/react/src/components/Toast/Toast.tsx
@@ -93,3 +93,5 @@ export const Toast = React.forwardRef((props, forwardedRef) => {
     </StyledToast>
   );
 }) as ForwardRefComponent<ToastElement, ToastProps>;
+
+Toast.displayName = 'Toast';

--- a/packages/react/src/components/Toaster/Toaster.tsx
+++ b/packages/react/src/components/Toaster/Toaster.tsx
@@ -95,3 +95,5 @@ export const Toaster = React.forwardRef((props, forwardedRef) => {
     </StyledToaster>
   );
 }) as ForwardRefComponent<ToasterElement, ToasterProps>;
+
+Toaster.displayName = 'Toaster';

--- a/packages/react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.tsx
@@ -73,3 +73,5 @@ export const Tooltip = React.forwardRef((props, forwardedRef) => {
     </>
   );
 }) as ForwardRefComponent<TooltipElement, TooltipProps>;
+
+Tooltip.displayName = 'Tooltip';

--- a/packages/react/src/components/TooltipContent/TooltipContent.tsx
+++ b/packages/react/src/components/TooltipContent/TooltipContent.tsx
@@ -28,3 +28,5 @@ export const TooltipContent = React.forwardRef((props, forwardedRef) => {
     </StyledTooltipContent>
   );
 }) as ForwardRefComponent<TooltipContentElement, TooltipContentProps>;
+
+TooltipContent.displayName = 'TooltipContent';

--- a/packages/react/src/components/Transition/Transition.tsx
+++ b/packages/react/src/components/Transition/Transition.tsx
@@ -119,3 +119,5 @@ export const Transition = React.forwardRef<HTMLElement, TransitionProps>((props,
     </TransitionComponent>
   );
 });
+
+Transition.displayName = 'Transition';

--- a/packages/react/src/components/Typography/Typography.tsx
+++ b/packages/react/src/components/Typography/Typography.tsx
@@ -40,3 +40,5 @@ export const Typography = createComponent<TypographyOptions>((props, forwardedRe
 
   return <Comp {...other} ref={forwardedRef} className={classes} />;
 });
+
+Typography.displayName = 'Typography';

--- a/packages/react/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/react/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -25,3 +25,5 @@ export const VisuallyHidden = createComponent<VisuallyHiddenOptions>((props, for
 
   return <Comp {...mergeProps(visuallyHiddenProps, other)} ref={forwardedRef} />;
 });
+
+VisuallyHidden.displayName = 'VisuallyHidden';

--- a/packages/react/src/components/action-card/action-card.tsx
+++ b/packages/react/src/components/action-card/action-card.tsx
@@ -41,6 +41,8 @@ const ActionCard = React.forwardRef((props, forwardedRef) => {
   );
 }) as ForwardRefComponent<ActionCardElement, ActionCardProps>;
 
+ActionCard.displayName = 'ActionCard';
+
 /* -------------------------------------------------------------------------------------------------
  * ActionCardBody
  * -----------------------------------------------------------------------------------------------*/
@@ -63,6 +65,8 @@ const ActionCardBody = React.forwardRef((props, forwardedRef) => {
     </StyledActionCardBody>
   );
 }) as ForwardRefComponent<ActionCardBodyElement, ActionCardBodyProps>;
+
+ActionCardBody.displayName = 'ActionCardBody';
 
 /* -------------------------------------------------------------------------------------------------
  * ActionCardHeader
@@ -87,6 +91,8 @@ const ActionCardHeader = React.forwardRef((props, forwardedRef) => {
     </StyledActionCardHeader>
   );
 }) as ForwardRefComponent<ActionCardHeaderElement, ActionCardHeaderProps>;
+
+ActionCardHeader.displayName = 'ActionCardHeader';
 
 /* -------------------------------------------------------------------------------------------------
  * ActionCardImage
@@ -125,6 +131,8 @@ const ActionCardImage = React.forwardRef((props, forwardedRef) => {
     />
   );
 }) as ForwardRefComponent<ActionCardImageElement, ActionCardImageProps>;
+
+ActionCardImage.displayName = 'ActionCardImage';
 
 export type { ActionCardBodyProps, ActionCardHeaderProps, ActionCardImageProps, ActionCardProps };
 export { ActionCard, ActionCardBody, ActionCardHeader, ActionCardImage };

--- a/packages/react/src/components/avatar/avatar.tsx
+++ b/packages/react/src/components/avatar/avatar.tsx
@@ -80,5 +80,7 @@ const Avatar = React.forwardRef((props, forwardedRef) => {
   );
 }) as ForwardRefComponent<AvatarElement, AvatarProps>;
 
+Avatar.displayName = 'Avatar';
+
 export type { AvatarProps };
 export { Avatar };

--- a/packages/react/src/components/box/box.tsx
+++ b/packages/react/src/components/box/box.tsx
@@ -28,5 +28,7 @@ const Box = React.forwardRef((props, forwardedRef) => {
   );
 }) as ForwardRefComponent<BoxElement, BoxProps>;
 
+Box.displayName = 'Box';
+
 export type { BoxProps };
 export { Box };

--- a/packages/react/src/components/breadcrumb/breadcrumb.tsx
+++ b/packages/react/src/components/breadcrumb/breadcrumb.tsx
@@ -28,6 +28,8 @@ const Breadcrumb = React.forwardRef((props, forwardedRef) => {
   );
 }) as ForwardRefComponent<BreadcrumbElement, BreadcrumbProps>;
 
+Breadcrumb.displayName = 'Breadcrumb';
+
 /* -------------------------------------------------------------------------------------------------
  * BreadcrumbItem
  * -----------------------------------------------------------------------------------------------*/
@@ -53,6 +55,8 @@ const BreadcrumbItem = React.forwardRef((props, forwardedRef) => {
     </StyledBreadcrumbItem>
   );
 }) as ForwardRefComponent<BreadcrumbItemElement, BreadcrumbItemProps>;
+
+BreadcrumbItem.displayName = 'BreadcrumbItem';
 
 export type { BreadcrumbItemProps, BreadcrumbProps };
 export { Breadcrumb, BreadcrumbItem };

--- a/packages/react/src/components/button/button.tsx
+++ b/packages/react/src/components/button/button.tsx
@@ -170,6 +170,8 @@ const Button = React.forwardRef((props, forwardedRef) => {
   );
 }) as ForwardRefComponent<ButtonElement, ButtonProps>;
 
+Button.displayName = 'Button';
+
 /* -------------------------------------------------------------------------------------------------
  * ButtonGroup
  * -----------------------------------------------------------------------------------------------*/
@@ -240,6 +242,8 @@ const ButtonGroup = React.forwardRef((props, forwardedRef) => {
   );
 }) as ForwardRefComponent<ButtonGroupElement, ButtonGroupProps>;
 
+ButtonGroup.displayName = 'ButtonGroup';
+
 /* -------------------------------------------------------------------------------------------------
  * IconButton
  * -----------------------------------------------------------------------------------------------*/
@@ -265,6 +269,8 @@ const IconButton = React.forwardRef((props, forwardedRef) => {
     />
   );
 }) as ForwardRefComponent<IconButtonElement, IconButtonProps>;
+
+IconButton.displayName = 'IconButton';
 
 export type { ButtonGroupProps, ButtonProps, IconButtonProps };
 export { Button, ButtonGroup, IconButton };

--- a/packages/react/src/components/container/container.tsx
+++ b/packages/react/src/components/container/container.tsx
@@ -42,5 +42,7 @@ const Container = React.forwardRef((props, forwardedRef) => {
   );
 }) as ForwardRefComponent<ContainerElement, ContainerProps>;
 
+Container.displayName = 'Container';
+
 export type { ContainerProps };
 export { Container };

--- a/packages/react/src/components/flex/flex.tsx
+++ b/packages/react/src/components/flex/flex.tsx
@@ -63,5 +63,7 @@ const Flex = React.forwardRef((props, forwardedRef) => {
   );
 }) as ForwardRefComponent<FlexElement, FlexProps>;
 
+Flex.displayName = 'Flex';
+
 export type { FlexProps };
 export { Flex };

--- a/packages/react/src/components/grid/grid.tsx
+++ b/packages/react/src/components/grid/grid.tsx
@@ -76,6 +76,8 @@ const Grid = React.forwardRef((props, forwardedRef) => {
   );
 }) as ForwardRefComponent<GridElement, GridProps>;
 
+Grid.displayName = 'Grid';
+
 /* -------------------------------------------------------------------------------------------------
  * GridItem
  * -----------------------------------------------------------------------------------------------*/
@@ -155,6 +157,8 @@ const GridItem = React.forwardRef((props, forwardedRef) => {
     />
   );
 }) as ForwardRefComponent<GridItemElement, GridItemProps>;
+
+GridItem.displayName = 'GridItem';
 
 export type { GridItemProps, GridProps };
 export { Grid, GridItem };

--- a/packages/react/src/components/stack/stack.tsx
+++ b/packages/react/src/components/stack/stack.tsx
@@ -39,6 +39,7 @@ const Stack = React.forwardRef((props, forwardedRef) => {
     />
   );
 }) as ForwardRefComponent<StackElement, StackProps>;
+Stack.displayName = 'Stack';
 
 export type { StackProps };
 export { Stack };


### PR DESCRIPTION
<!--- We really appreciated your pull request! -->

Closes # https://project44.atlassian.net/browse/MI-36

## 📝 Description

> For people who’re new to our codebase it is very hard to find out exact component name, we need to search through data-testid and then figure out component name from that. and in case data test id is not present we have to go to parent who has data test id and then trace component from there.

## Screenshots

Without displayName
![without displayName](https://github.com/project44/manifest/assets/147403156/6f95526f-e7b0-4320-8fc9-426da7cca412)


With displayName
![with displayName](https://github.com/project44/manifest/assets/147403156/d8f8f593-f745-4538-a0fb-fa9ec0f4067b)




> Please provide screenshots for any visual changes

## Merge checklist

- [x] Added/updated tests
- [x] Added changeset
