### PR TITLE
fix: use storybook-manifest name instead of storybook

### DIFF
--- a/.changeset/hungry-zoos-rescue.md
+++ b/.changeset/hungry-zoos-rescue.md
@@ -1,0 +1,5 @@
+---
+'storybook-manifest': patch
+---
+
+Updated package name

--- a/.changeset/kind-teachers-itch.md
+++ b/.changeset/kind-teachers-itch.md
@@ -1,5 +1,4 @@
 ---
-'storybook': patch
 'website': patch
 '@project44-manifest/css': patch
 '@project44-manifest/design-tokens': patch


### PR DESCRIPTION
<!--- We really appreciated your pull request! -->

## 📝 Description

> We need to update name of package for storybook as with v7 storybook is used as script and should be added in devdependecies.

## Screenshots

> Please provide screenshots for any visual changes

## Merge checklist

- [ ] Added/updated tests
- [x] Added changeset
