### PR TITLE
fix: website colors docs

### DIFF
--- a/.changeset/beige-books-live.md
+++ b/.changeset/beige-books-live.md
@@ -1,0 +1,5 @@
+---
+'website': patch
+---
+
+fix colors page

--- a/apps/website/docs/core/colors.mdx
+++ b/apps/website/docs/core/colors.mdx
@@ -27,9 +27,9 @@ The primary application color
 
 ## Text
 
-Global border colors
+Global text colors
 
-<Swatches name="border" />
+<Swatches name="text" />
 
 ## Palette
 


### PR DESCRIPTION
Fix documentation page, text colors block was incorrect

## Screenshots

> Please provide screenshots for any visual changes

## Merge checklist

- [ ] Added/updated tests
- [ ] Added changeset
