### PR TITLE
fix: made changes to add isSelected prop to menuGroup

### DIFF
--- a/.changeset/gold-spies-retire.md
+++ b/.changeset/gold-spies-retire.md
@@ -1,0 +1,6 @@
+---
+'@project44-manifest/react': patch
+---
+
+added isSelected prop to menu group to highlight it when it is not expanded and one of it's child is
+selected

--- a/packages/react/src/components/MenuGroup/MenuGroup.tsx
+++ b/packages/react/src/components/MenuGroup/MenuGroup.tsx
@@ -44,11 +44,11 @@ export const MenuGroup = React.forwardRef((props, forwardedRef) => {
       <MenuItem
         {...itemProps}
         endIcon={<StyledIcon {...iconProps} isExpanded={isExpanded} />}
+        isSelected={isSelected && !isExpanded} // Need to highlight menu group only if it not expanded
         label={label}
         labelProps={labelProps}
         startIcon={startIcon}
         onClick={handleExpand}
-        isSelected={isSelected && !isExpanded} // Need to highlight menu group only if it not expanded
       />
       <MenuGroupProvider value={{ isGrouped: true }}>
         <Collapse appear unmountOnExit duration={100} in={isExpanded}>

--- a/packages/react/src/components/MenuGroup/MenuGroup.tsx
+++ b/packages/react/src/components/MenuGroup/MenuGroup.tsx
@@ -23,6 +23,7 @@ export const MenuGroup = React.forwardRef((props, forwardedRef) => {
     labelProps,
     onExpandedChange = noop,
     startIcon,
+    isSelected = false,
     ...other
   } = props;
 
@@ -47,6 +48,7 @@ export const MenuGroup = React.forwardRef((props, forwardedRef) => {
         labelProps={labelProps}
         startIcon={startIcon}
         onClick={handleExpand}
+        isSelected={isSelected && !isExpanded} // Need to highlight menu group only if it not expanded
       />
       <MenuGroupProvider value={{ isGrouped: true }}>
         <Collapse appear unmountOnExit duration={100} in={isExpanded}>

--- a/packages/react/src/components/MenuGroup/MenuGroup.types.ts
+++ b/packages/react/src/components/MenuGroup/MenuGroup.types.ts
@@ -42,4 +42,8 @@ export interface MenuGroupProps {
    * Icon added before the button text.
    */
   startIcon?: React.ReactElement;
+  /**
+   * Adds a highlight style when a submenu is selected and menu group is not in expanded mode.
+   */
+  isSelected?: boolean;
 }

--- a/packages/react/src/components/SideNavigationMenuGroup/SideNavigationMenuGroup.tsx
+++ b/packages/react/src/components/SideNavigationMenuGroup/SideNavigationMenuGroup.tsx
@@ -9,7 +9,7 @@ import type {
 } from './SideNavigationMenuGroup.types';
 
 export const SideNavigationMenuGroup = React.forwardRef((props, forwardedRef) => {
-  const { className: classNameProp, isExpanded: isExpandedProp, ...other } = props;
+  const { className: classNameProp, isExpanded: isExpandedProp, isSelected, ...other } = props;
 
   const { isOpen } = useNavigation();
 
@@ -22,6 +22,7 @@ export const SideNavigationMenuGroup = React.forwardRef((props, forwardedRef) =>
       className={className}
       isExpanded={!isOpen ? false : undefined}
       isOpen={isOpen}
+      isSelected={isSelected}
     />
   );
 }) as ForwardRefComponent<SideNavigationMenuGroupElement, SideNavigationMenuGroupProps>;


### PR DESCRIPTION
<!--- We really appreciated your pull request! -->

Closes # https://project44.atlassian.net/browse/MI-19

## 📝 Description

> Made changes to add isSelected property which can be used to highlight menuGroup when one of it's child is selected and it is in not expanded mode.

## Screenshots

> Please provide screenshots for any visual changes

## Merge checklist

- [x] Added/updated tests
- [x] Added changeset
