### PR TITLE
fix(daterangepicker): updated caculation for yesterday

### DIFF
--- a/.changeset/rare-cougars-carry.md
+++ b/.changeset/rare-cougars-carry.md
@@ -1,0 +1,5 @@
+---
+'@project44-manifest/react': patch
+---
+
+fix: updated logic to calculate the start and end of Yesterday on date range picker

--- a/packages/react/src/components/CalendarRanges/defaultDefinedRanges.ts
+++ b/packages/react/src/components/CalendarRanges/defaultDefinedRanges.ts
@@ -43,8 +43,8 @@ const calendarDate = createCalendarDate(defaultDate);
 export const defineds = {
   startOfToday: calendarDate,
   endOfToday: calendarDate,
-  startOfYesterday: addDays(calendarDate, -2),  // since addDays includes current day in the range
-  endOfYesterday: addDays(calendarDate, -2),    // to get 1 day previous we have to subtract 2
+  startOfYesterday: addDays(calendarDate, -2), // since addDays includes current day in the range
+  endOfYesterday: addDays(calendarDate, -2), // to get 1 day previous we have to subtract 2
   sevenDaysAgo: addDays(calendarDate, -7),
   thirtyDaysAgo: addDays(calendarDate, -30),
   endOfWeek: endOfWeek(calendarDate, 'en-US'),

--- a/packages/react/src/components/CalendarRanges/defaultDefinedRanges.ts
+++ b/packages/react/src/components/CalendarRanges/defaultDefinedRanges.ts
@@ -43,8 +43,8 @@ const calendarDate = createCalendarDate(defaultDate);
 export const defineds = {
   startOfToday: calendarDate,
   endOfToday: calendarDate,
-  startOfYesterday: addDays(calendarDate, -1),
-  endOfYesterday: addDays(calendarDate, -1),
+  startOfYesterday: addDays(calendarDate, -2),  // since addDays includes current day in the range
+  endOfYesterday: addDays(calendarDate, -2),    // to get 1 day previous we have to subtract 2
   sevenDaysAgo: addDays(calendarDate, -7),
   thirtyDaysAgo: addDays(calendarDate, -30),
   endOfWeek: endOfWeek(calendarDate, 'en-US'),

--- a/packages/react/src/components/DateRangePicker/tests/DateRangePicker.test.tsx
+++ b/packages/react/src/components/DateRangePicker/tests/DateRangePicker.test.tsx
@@ -262,4 +262,43 @@ describe('@project44-manifest/components - DateRangePicker', () => {
       end: chosenRange?.value.end,
     });
   });
+
+  it('should render the yesterday date when clicked on yesterday', () => {
+    const onChange = jest.fn();
+
+    render(
+      <OverlayProvider>
+        <DateRangePicker
+          showCalendar
+          showRanges
+          aria-label="Calendar"
+          defaultValue={{ start: new CalendarDate(2022, 7, 2), end: new CalendarDate(2022, 7, 12) }}
+          onChange={onChange}
+        />
+      </OverlayProvider>,
+    );
+    expect(screen.getByText('Jul 2, 2022 - Jul 12, 2022')).toBeVisible();
+
+    fireEvent.click(screen.getByRole('button'));
+
+    const dialog = screen.getByRole('presentation');
+
+    expect(dialog).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Yesterday'));
+    act(() => {
+      jest.runAllTimers();
+    });
+    const today = new Date();
+
+    const yesterday = new Date(today);
+      yesterday.setDate(today.getDate() - 1);
+
+    const yesterdayDateString = `${yesterday.toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    })}`;
+    expect(screen.getByText(`${yesterdayDateString} - ${yesterdayDateString}`)).toBeVisible();
+  });
 });

--- a/packages/react/src/components/DateRangePicker/tests/DateRangePicker.test.tsx
+++ b/packages/react/src/components/DateRangePicker/tests/DateRangePicker.test.tsx
@@ -292,7 +292,7 @@ describe('@project44-manifest/components - DateRangePicker', () => {
     const today = new Date();
 
     const yesterday = new Date(today);
-      yesterday.setDate(today.getDate() - 1);
+    yesterday.setDate(today.getDate() - 1);
 
     const yesterdayDateString = `${yesterday.toLocaleDateString(undefined, {
       month: 'short',


### PR DESCRIPTION
<!--- We really appreciated your pull request! -->

Closes # <!-- Github issue # here -->

## 📝 Description
This PR fixes an issue with the relative date range selection component
On selecting Yesterday the component selects the current date.

Fixed this by passing `-2` when calculating `startOfYesterday` and `endOfYesterday`

## Screenshots
>Bug
<img width="600" alt="Screenshot 2024-01-05 at 2 39 47 PM" src="https://github.com/project44/manifest/assets/137487111/3aac7ae9-8784-4350-986e-2ea116f4dec1"> 


>Fixed
<img width="600" alt="Screenshot 2024-01-05 at 2 38 33 PM" src="https://github.com/project44/manifest/assets/137487111/3c72dd10-9a73-47d9-ae47-bde707f65c3b">

## Merge checklist

- [x] Added/updated tests
- [x] Added changeset
