### PR TITLE
feat(dialogv2) : added dialog version 2

### DIFF
--- a/.changeset/pretty-bears-nail.md
+++ b/.changeset/pretty-bears-nail.md
@@ -1,0 +1,6 @@
+---
+'storybook-manifest': minor
+'@project44-manifest/react': minor
+---
+
+Added dialog version 2

--- a/apps/storybook/.storybook/manager.js
+++ b/apps/storybook/.storybook/manager.js
@@ -1,4 +1,4 @@
-import { addons } from '@storybook/addons';
+import { addons } from '@storybook/manager-api';
 import theme from './theme';
 
 addons.setConfig({ theme });

--- a/packages/react/src/components/Dialogv2/dialogv2.styles.ts
+++ b/packages/react/src/components/Dialogv2/dialogv2.styles.ts
@@ -1,0 +1,37 @@
+import { pxToRem, styled } from '@project44-manifest/react-styles';
+
+export const DialogV2Wrapper = styled('div', {
+  display: 'flex',
+  backgroundColor: '$background-primary',
+  borderRadius: '$small',
+  boxShadow: '$small',
+  boxSizing: 'border-box',
+  flexDirection: 'column',
+  outline: 0,
+  padding: '$large',
+  position: 'relative',
+  maxHeight: 'calc(100vh - 75px) !important',
+  overflowY: 'auto',
+  variants: {
+    size: {
+      small: {
+        width: pxToRem(480),
+      },
+      medium: {
+        width: pxToRem(640),
+      },
+      large: {
+        width: pxToRem(960),
+      },
+    },
+    edgeToEdge: {
+      noPadding: {
+        padding: '0px',
+      },
+    },
+  },
+  defaultVariants: {
+    size: 'large',
+    edgeToEdge: '',
+  },
+});

--- a/packages/react/src/components/Dialogv2/dialogv2.tsx
+++ b/packages/react/src/components/Dialogv2/dialogv2.tsx
@@ -11,6 +11,7 @@ import { useDialog } from '@react-aria/dialog';
 import { DialogProvider } from '../Dialog/Dialog.context';
 import { mergeProps } from '@react-aria/utils';
 import { Modal } from '../Modal';
+import { ModalPosition } from '../Modal/Modal.types';
 
 export enum DialogV2Size {
   small = 'small',
@@ -30,6 +31,7 @@ export interface DialogV2Props {
   isKeyboardDismissDisabled?: boolean;
   size?: DialogV2Size;
   edgeToEdge?: boolean;
+  position?: ModalPosition;
 }
 
 export const DialogV2Impl = React.forwardRef((props, forwardedRef) => {
@@ -89,7 +91,13 @@ export const DialogV2Impl = React.forwardRef((props, forwardedRef) => {
 DialogV2Impl.displayName = 'DialogImpl';
 
 export const DialogV2 = React.forwardRef((props, forwardedRef) => {
-  const { isDismissable = true, isKeyboardDismissDisabled = false, isOpen, ...other } = props;
+  const {
+    isDismissable = true,
+    isKeyboardDismissDisabled = false,
+    isOpen,
+    position,
+    ...other
+  } = props;
 
   const { onClose } = other.headerProps;
   return (
@@ -99,6 +107,7 @@ export const DialogV2 = React.forwardRef((props, forwardedRef) => {
       isOpen={isOpen}
       onClose={onClose}
       data-testid="dialogV2Modal"
+      position={position}
     >
       <DialogV2Impl {...other} isDismissable={isDismissable} />
     </Modal>

--- a/packages/react/src/components/Dialogv2/dialogv2.tsx
+++ b/packages/react/src/components/Dialogv2/dialogv2.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { ForwardRefComponent } from '@project44-manifest/react-types';
+import { DialogElement } from '../Dialog/Dialog.types';
+import { DialogV2Wrapper } from './dialogv2.styles';
+import { DialogHeader } from '../DialogHeader';
+import { DialogContent } from '../DialogContent';
+import { DialogFooter } from '../DialogFooter';
+import { cx } from '@project44-manifest/react-styles';
+import { useMergedRef } from '../../hooks';
+import { useDialog } from '@react-aria/dialog';
+import { DialogProvider } from '../Dialog/Dialog.context';
+import { mergeProps } from '@react-aria/utils';
+import { Modal } from '../Modal';
+
+export enum DialogV2Size {
+  small = 'small',
+  medium = 'medium',
+  large = 'large',
+}
+
+export interface DialogV2Props {
+  isOpen?: boolean;
+  headerProps: {
+    title: string;
+    onClose: () => void;
+  };
+  body: string | React.ReactNode;
+  footer?: string | React.ReactNode;
+  isDismissable?: boolean;
+  isKeyboardDismissDisabled?: boolean;
+  size?: DialogV2Size;
+  edgeToEdge?: boolean;
+}
+
+export const DialogV2Impl = React.forwardRef((props, forwardedRef) => {
+  const {
+    as,
+    children,
+    className: classNameProp,
+    isDismissable,
+    headerProps,
+    body,
+    footer,
+    edgeToEdge,
+    size = DialogV2Size.medium,
+    ...other
+  } = props;
+
+  const { title, onClose } = headerProps;
+
+  const dialogRef = React.useRef<HTMLDivElement>(null);
+  const mergedRef = useMergedRef(dialogRef, forwardedRef);
+
+  const { dialogProps, titleProps } = useDialog({ role: 'dialog' }, dialogRef);
+
+  const context = React.useMemo(
+    () => ({
+      isDismissable,
+      titleProps,
+      onClose,
+    }),
+    [isDismissable, onClose, titleProps],
+  );
+
+  const className = cx('manifest-dialog', classNameProp, {
+    [`manifest-dialog-${size}`]: size,
+    [`manifest-dialog-edgeToEdge`]: edgeToEdge,
+  });
+
+  return (
+    <DialogProvider value={context}>
+      <DialogV2Wrapper
+        {...mergeProps(dialogProps, other)}
+        ref={mergedRef}
+        as={as}
+        className={className}
+        size={size}
+        edgeToEdge={edgeToEdge ? 'noPadding' : undefined}
+        data-testid={'dialogV2Wrapper'}
+      >
+        <DialogHeader data-testid={'dialogV2Header'}>{title}</DialogHeader>
+        <DialogContent data-testid={'dialogV2Content'}>{body}</DialogContent>
+        {footer && <DialogFooter data-testid={'dialogV2Footer'}>{footer}</DialogFooter>}
+      </DialogV2Wrapper>
+    </DialogProvider>
+  );
+}) as ForwardRefComponent<DialogElement, DialogV2Props>;
+
+DialogV2Impl.displayName = 'DialogImpl';
+
+export const DialogV2 = React.forwardRef((props, forwardedRef) => {
+  const { isDismissable = true, isKeyboardDismissDisabled = false, isOpen, ...other } = props;
+
+  const { onClose } = other.headerProps;
+  return (
+    <Modal
+      isDismissable={isDismissable}
+      isKeyboardDismissDisabled={isKeyboardDismissDisabled}
+      isOpen={isOpen}
+      onClose={onClose}
+      data-testid="dialogV2Modal"
+    >
+      <DialogV2Impl {...other} isDismissable={isDismissable} />
+    </Modal>
+  );
+}) as ForwardRefComponent<DialogElement, DialogV2Props>;
+
+DialogV2.displayName = 'DialogV2';

--- a/packages/react/src/components/Dialogv2/story/Dialogv2.stories.tsx
+++ b/packages/react/src/components/Dialogv2/story/Dialogv2.stories.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Meta, StoryFn } from '@storybook/react';
 import { Button } from '../../..';
 import { DialogV2, DialogV2Props, DialogV2Size } from '../dialogv2';
+import { ModalPosition } from '../../Modal/Modal.types';
 
 const meta: Meta<DialogV2Props> = {
   component: DialogV2,
@@ -9,6 +10,10 @@ const meta: Meta<DialogV2Props> = {
   argTypes: {
     size: {
       options: [DialogV2Size.small, DialogV2Size.medium, DialogV2Size.large],
+      control: { type: 'radio' },
+    },
+    position: {
+      options: [ModalPosition.top, ModalPosition.center],
       control: { type: 'radio' },
     },
   },
@@ -57,4 +62,5 @@ Default.args = {
   isKeyboardDismissDisabled: true,
   edgeToEdge: false,
   size: DialogV2Size.small,
+  position: ModalPosition.top,
 };

--- a/packages/react/src/components/Dialogv2/story/Dialogv2.stories.tsx
+++ b/packages/react/src/components/Dialogv2/story/Dialogv2.stories.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { Meta, StoryFn } from '@storybook/react';
+import { Button } from '../../..';
+import { DialogV2, DialogV2Props, DialogV2Size } from '../dialogv2';
+
+const meta: Meta<DialogV2Props> = {
+  component: DialogV2,
+  title: 'Components/Dialogv2',
+  argTypes: {
+    size: {
+      options: [DialogV2Size.small, DialogV2Size.medium, DialogV2Size.large],
+      control: { type: 'radio' },
+    },
+  },
+};
+
+export default meta;
+
+export const Default: StoryFn<DialogV2Props> = (args: DialogV2Props) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  const handleClose = React.useCallback(() => void setIsOpen(false), []);
+  const handleOpen = React.useCallback(() => void setIsOpen(true), []);
+
+  const props: DialogV2Props = {
+    isOpen: isOpen,
+    headerProps: {
+      title: 'Dialog Title',
+      onClose: handleClose,
+    },
+    body: `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+    ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+    ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
+    reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
+    sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+    est laborum.`,
+    footer: (
+      <>
+        <Button variant="secondary" onPress={handleClose}>
+          Close
+        </Button>
+        <Button onPress={handleClose}>Confirm</Button>
+      </>
+    ),
+  };
+
+  return (
+    <>
+      <Button onPress={handleOpen}>Open Dialog</Button>
+      <DialogV2 {...args} {...props}></DialogV2>
+    </>
+  );
+};
+
+Default.args = {
+  isDismissable: true,
+  isKeyboardDismissDisabled: true,
+  edgeToEdge: false,
+  size: DialogV2Size.small,
+};

--- a/packages/react/src/components/Dialogv2/tests/dialogV2.test.tsx
+++ b/packages/react/src/components/Dialogv2/tests/dialogV2.test.tsx
@@ -1,0 +1,70 @@
+import { act, render, screen } from '@testing-library/react';
+import { DialogV2, DialogV2Size } from '../dialogv2';
+
+beforeAll(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+
+  act(() => {
+    jest.runAllTimers();
+  });
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
+it('should render dialogV2', () => {
+  let onClose = jest.fn();
+  render(
+    <DialogV2
+      isOpen={true}
+      body="Some string"
+      headerProps={{
+        onClose: onClose,
+        title: 'some title',
+      }}
+    />,
+  );
+
+  expect(screen.getByTestId('dialogV2Wrapper')).toBeInTheDocument();
+});
+
+it('should render footer', () => {
+  let onClose = jest.fn();
+  render(
+    <DialogV2
+      isOpen={true}
+      body="Some string"
+      headerProps={{
+        onClose: onClose,
+        title: 'some title',
+      }}
+      footer="Some footer text that i need to place"
+    />,
+  );
+
+  expect(screen.getByTestId('dialogV2Footer')).toBeInTheDocument();
+});
+
+it('should react to size', () => {
+  let onClose = jest.fn();
+  render(
+    <DialogV2
+      size={DialogV2Size.small}
+      isOpen={true}
+      body="Some string"
+      headerProps={{
+        onClose: onClose,
+        title: 'some title',
+      }}
+      footer="Some footer text that i need to place"
+    />,
+  );
+  expect(screen.getByTestId('dialogV2Wrapper').className.includes('manifest-dialog-small')).toBe(
+    true,
+  );
+});

--- a/packages/react/src/components/Modal/Modal.styles.ts
+++ b/packages/react/src/components/Modal/Modal.styles.ts
@@ -46,6 +46,23 @@ export const StyledModalWrapper = styled('div', {
         visibility: 'visible',
       },
     },
+    position: {
+      top: {
+        top: '64px',
+        inlineSize: 'auto',
+        left: '0px',
+        right: '0px',
+        alignItems: 'flex-start',
+      },
+      center: {
+        alignItems: 'center',
+        justifyContent: 'center',
+      },
+    },
+  },
+
+  defaultVariants: {
+    position: 'top',
   },
 });
 

--- a/packages/react/src/components/Modal/Modal.tsx
+++ b/packages/react/src/components/Modal/Modal.tsx
@@ -6,7 +6,7 @@ import { useMergedRef } from '../../hooks';
 import { mergeProps } from '../../utils';
 import { Overlay } from '../Overlay';
 import { StyledModal, StyledModalWrapper, StyledUnderlay } from './Modal.styles';
-import type { ModalElement, ModalProps } from './Modal.types';
+import { ModalElement, ModalProps, ModalPosition } from './Modal.types';
 
 /**
  * Modal implementation; Need to initialize the overlay component before calling
@@ -24,6 +24,7 @@ const ModalImpl = React.forwardRef((props, forwardedRef) => {
     isKeyboardDismissDisabled,
     isOpen,
     onClose,
+    position = ModalPosition.top,
     ...other
   } = props;
 
@@ -51,7 +52,7 @@ const ModalImpl = React.forwardRef((props, forwardedRef) => {
   return (
     <>
       <StyledUnderlay {...underlayProps} className="manifest-underlay" isOpen={isOpen} />
-      <StyledModalWrapper className="manifest-modal-wrapper" isOpen={isOpen}>
+      <StyledModalWrapper className="manifest-modal-wrapper" isOpen={isOpen} position={position}>
         <StyledModal
           {...mergeProps(overlayProps, other)}
           ref={mergedRef}

--- a/packages/react/src/components/Modal/Modal.types.ts
+++ b/packages/react/src/components/Modal/Modal.types.ts
@@ -1,5 +1,10 @@
 import type { CSS } from '@project44-manifest/react-styles';
 
+export enum ModalPosition {
+  top = 'top',
+  center = 'center',
+}
+
 export type ModalElement = 'div';
 
 export interface ModalProps {
@@ -27,4 +32,9 @@ export interface ModalProps {
    * Handler that is called when the modal should close.
    */
   onClose?: () => void;
+
+  /**
+   * Handles position of modal wrapper
+   */
+  position?: ModalPosition;
 }


### PR DESCRIPTION
<!--- We really appreciated your pull request! -->

Closes # https://project44.atlassian.net/browse/MI-28

## 📝 Description

There are many places where we use dialog, currently we have to stich dialog header, content and footer explicitly to be able to create a dialog which is time taking, so to address this building this new dialog version where content and footer can be just sent as prop along with few other props as well.

## Screenshots
<img width="1728" alt="Screenshot 2024-02-21 at 11 06 45 AM" src="https://github.com/project44/manifest/assets/147403156/65b2258c-ce5f-4ac4-9649-45cd36f85146">


## Merge checklist

- [x] Added/updated tests
- [x] Added changeset
