### PR TITLE
fix: add key in NavigationTabs

### DIFF
--- a/.changeset/sharp-lemons-cheer.md
+++ b/.changeset/sharp-lemons-cheer.md
@@ -1,0 +1,5 @@
+---
+'@project44-manifest/react': patch
+---
+
+add key to NavigationTabs button element

--- a/packages/react/src/components/NavigationTabs/index.tsx
+++ b/packages/react/src/components/NavigationTabs/index.tsx
@@ -94,9 +94,9 @@ export const NavigationTabs = React.forwardRef((props, forwardedRef) => {
             title={toolTip}
           >
             <Button
+              key={label}
               aria-checked={isActive}
               aria-label={label}
-              key={label}
               css={{
                 backgroundColor: 'transparent',
                 color: '$palette-white',

--- a/packages/react/src/components/NavigationTabs/index.tsx
+++ b/packages/react/src/components/NavigationTabs/index.tsx
@@ -96,6 +96,7 @@ export const NavigationTabs = React.forwardRef((props, forwardedRef) => {
             <Button
               aria-checked={isActive}
               aria-label={label}
+              key={label}
               css={{
                 backgroundColor: 'transparent',
                 color: '$palette-white',


### PR DESCRIPTION
## 📝 Description

- Add key to `Button` within `Tooltip` to remove console error

## Screenshots

- N/A

## Merge checklist

- [x] Added/updated tests
- [ ] Added changeset
