### PR TITLE
feat: INITIATE-3761: Expand to subrow row buttons hover state

### DIFF
--- a/.changeset/two-horses-bow.md
+++ b/.changeset/two-horses-bow.md
@@ -1,0 +1,5 @@
+---
+'@project44-manifest/react': minor
+---
+
+Adding hover state to expand button

--- a/packages/react/src/components/DataTable/components/DataTableExpandButton/DataTableExpandButton.tsx
+++ b/packages/react/src/components/DataTable/components/DataTableExpandButton/DataTableExpandButton.tsx
@@ -31,7 +31,12 @@ export function DataTableExpandButton<TData extends RowData>(
   return (
     <IconButton
       {...parsedProps}
-      css={{ display: canExpand || showCanExpandIcon ? 'block' : 'none' }}
+      css={{
+        display: canExpand || showCanExpandIcon ? 'block' : 'none',
+        '&:hover': {
+          bgColor: '$colors$palette-grey-300',
+        },
+      }}
       isDisabled={isLoading || !canExpand}
       size="small"
       variant="tertiary"

--- a/packages/react/src/components/DataTable/components/DataTableExpandButton/DataTableExpandButton.tsx
+++ b/packages/react/src/components/DataTable/components/DataTableExpandButton/DataTableExpandButton.tsx
@@ -32,7 +32,7 @@ export function DataTableExpandButton<TData extends RowData>(
     <IconButton
       {...parsedProps}
       css={{
-        display: canExpand || showCanExpandIcon ? 'flex' : 'none',
+        display: canExpand || showCanExpandIcon ? 'undefined' : 'none',
         '&:hover': {
           bgColor: '$palette-grey-300',
         },

--- a/packages/react/src/components/DataTable/components/DataTableExpandButton/DataTableExpandButton.tsx
+++ b/packages/react/src/components/DataTable/components/DataTableExpandButton/DataTableExpandButton.tsx
@@ -32,9 +32,9 @@ export function DataTableExpandButton<TData extends RowData>(
     <IconButton
       {...parsedProps}
       css={{
-        display: canExpand || showCanExpandIcon ? 'block' : 'none',
+        display: canExpand || showCanExpandIcon ? 'flex' : 'none',
         '&:hover': {
-          bgColor: '$colors$palette-grey-300',
+          bgColor: '$palette-grey-300',
         },
       }}
       isDisabled={isLoading || !canExpand}

--- a/packages/react/src/components/DataTable/components/DataTableExpandButton/DataTableExpandButton.tsx
+++ b/packages/react/src/components/DataTable/components/DataTableExpandButton/DataTableExpandButton.tsx
@@ -32,7 +32,7 @@ export function DataTableExpandButton<TData extends RowData>(
     <IconButton
       {...parsedProps}
       css={{
-        display: canExpand || showCanExpandIcon ? 'undefined' : 'none',
+        display: canExpand || showCanExpandIcon ? undefined : 'none',
         '&:hover': {
           bgColor: '$palette-grey-300',
         },


### PR DESCRIPTION

Closes # [INITIATE-3761](https://project44.atlassian.net/browse/INITIATE-3761)

## 📝 Description
Expand to subrow row buttons hover state changed as per design request
> Add a brief description
Just added a hover state in styles
## Screenshots

<img width="1728" alt="Screenshot 2024-12-27 at 3 25 05 PM" src="https://github.com/user-attachments/assets/e5751034-3382-4e81-a6a7-48f5c1343e16" />
<img width="1728" alt="Screenshot 2024-12-27 at 3 25 08 PM" src="https://github.com/user-attachments/assets/4b269797-aef1-4a89-9218-0e22a349d3a5" />



## Merge checklist

- [ ] Added/updated tests
- [ ] Added changeset


[INITIATE-3761]: https://project44.atlassian.net/browse/INITIATE-3761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ