### PR TITLE
fix: copyable Tag animation state

### DIFF
--- a/.changeset/silver-kiwis-attend.md
+++ b/.changeset/silver-kiwis-attend.md
@@ -1,0 +1,5 @@
+---
+'@project44-manifest/react': patch
+---
+
+fixes animation for copyable tag component

--- a/packages/react/src/components/Tag/Tag.styles.ts
+++ b/packages/react/src/components/Tag/Tag.styles.ts
@@ -65,7 +65,7 @@ export const useStyles = css({
   },
 
   variants: {
-    isCopied: {
+    showCopiedAnimation: {
       true: {
         '@media (prefers-reduced-motion: no-preference)': {
           '.manifest-tag__text::before': {

--- a/packages/react/src/components/Tag/Tag.tsx
+++ b/packages/react/src/components/Tag/Tag.tsx
@@ -119,10 +119,16 @@ export const Tag = createComponent<TagOptions>((props, forwardedRef) => {
   }
 
   React.useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
     if (isCopied) {
       setShowCopiedAnimation(true);
-      setTimeout(() => void setShowCopiedAnimation(false), 600); // slightly less than animation duration
+      timeoutId = setTimeout(() => void setShowCopiedAnimation(false), 600); // slightly less than animation duration
     }
+    return () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    };
   }, [isCopied]);
 
   return (

--- a/packages/react/src/components/Tag/Tag.tsx
+++ b/packages/react/src/components/Tag/Tag.tsx
@@ -63,6 +63,9 @@ export const Tag = createComponent<TagOptions>((props, forwardedRef) => {
   } = props;
 
   const [isCopied, setIsCopied] = React.useState(false);
+
+  const [showCopiedAnimation, setShowCopiedAnimation] = React.useState(false);
+
   const childrenText = useChildrenTextContent(children);
 
   const removeButtonRef = React.useRef<HTMLButtonElement>(null);
@@ -107,12 +110,20 @@ export const Tag = createComponent<TagOptions>((props, forwardedRef) => {
     isDisabled,
     isHovered,
     isRemovable,
+    showCopiedAnimation,
   });
 
   if (isCopyable && (!label || label === '')) {
     // eslint-disable-next-line no-console
     console.warn('Tag component requires a label prop for click-to-copy');
   }
+
+  React.useEffect(() => {
+    if (isCopied) {
+      setShowCopiedAnimation(true);
+      setTimeout(() => setShowCopiedAnimation(false), 600); // slightly less than animation duration
+    }
+  }, [isCopied]);
 
   return (
     <Comp

--- a/packages/react/src/components/Tag/Tag.tsx
+++ b/packages/react/src/components/Tag/Tag.tsx
@@ -121,7 +121,7 @@ export const Tag = createComponent<TagOptions>((props, forwardedRef) => {
   React.useEffect(() => {
     if (isCopied) {
       setShowCopiedAnimation(true);
-      setTimeout(() => setShowCopiedAnimation(false), 600); // slightly less than animation duration
+      setTimeout(() => void setShowCopiedAnimation(false), 600); // slightly less than animation duration
     }
   }, [isCopied]);
 

--- a/packages/react/src/components/Tag/story/Tag.stories.tsx
+++ b/packages/react/src/components/Tag/story/Tag.stories.tsx
@@ -73,23 +73,23 @@ export const Copyable = () => (
       isCopyable
       aria-label="truckload tag"
       label="Truckload"
-      removeButtonProps={{ 'aria-label': 'remove truckload' }}
+      removeButtonProps={{ 'aria-label': 'copy truckload' }}
     >
       Truckload
     </Tag>
     <Tag
       isCopyable
       aria-label="truckload tag"
-      label="Tag"
-      removeButtonProps={{ 'aria-label': 'remove truckload' }}
+      label="Tag with long text"
+      removeButtonProps={{ 'aria-label': 'copy tag' }}
     >
-      Tag
+      Tag with long text
     </Tag>
     <Tag
       isCopyable
       aria-label="truckload tag"
       label="1"
-      removeButtonProps={{ 'aria-label': 'remove truckload' }}
+      removeButtonProps={{ 'aria-label': 'copy 1' }}
     >
       1
     </Tag>

--- a/packages/react/src/components/Tag/tests/Tag.test.tsx
+++ b/packages/react/src/components/Tag/tests/Tag.test.tsx
@@ -20,4 +20,28 @@ describe('tag', () => {
     fireEvent.click(screen.getByRole('button'));
     expect(onRemove).toHaveBeenCalledTimes(1);
   });
+
+  it('should show copy icon and copy text when clicked', () => {
+    const mockClipboard = { writeText: jest.fn().mockResolvedValue(undefined) };
+    Object.defineProperty(global.navigator, 'clipboard', {
+      value: mockClipboard,
+      writable: true,
+      configurable: true,
+    });
+
+    render(
+      <Tag isCopyable label="copy-me">
+        CopyMe
+      </Tag>,
+    );
+
+    expect(document.querySelector('.manifest-tag__copy-icon')).toBeInTheDocument();
+
+    // Click the tag to trigger copy
+    const tag = screen.getByText('CopyMe').closest('.manifest-tag');
+    fireEvent.click(tag!);
+
+    // Check that clipboard was called
+    expect(mockClipboard.writeText).toHaveBeenCalledWith('copy-me');
+  });
 });


### PR DESCRIPTION
<!--- We really appreciated your pull request! -->

Closes # <!-- Github issue # here -->

## 📝 Description
> Add a brief description

**Affected component:** 
Copyable variant of Tag 

**Issue:** 
The content inside ::before persisted after copy icon was clicked. For tag with long text, this ::before content overflowed the container even though the original text was ellipsed. 

**RCA:**
isCopied state wrongly controlled animation state.  

**Fix:** 
Separated the animation state which triggers on first copy only.

## Screenshots

> Please provide screenshots for any visual changes


After fix:

https://github.com/user-attachments/assets/86622db5-0106-4b57-8604-ae782898f236


Before fix: 


https://github.com/user-attachments/assets/a6b8ebae-a45a-4c45-9d8c-b03fa6c2fe35



## Merge checklist

- [x] Added/updated tests
- [x] Added changeset
