### PR TITLE
[CENGINE-6052] ci: migrate workflows to self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ on:
 jobs:
   validate:
     name: Validate
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: ${{ fromJson(vars.SELF_HOSTED_RUNNER) }}
 
     steps:
       - name: Checkout branch

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -26,7 +26,8 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: ${{ fromJson(vars.SELF_HOSTED_RUNNER) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,7 +8,8 @@ on:
 jobs:
   conventional:
     name: Conventional title
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: ${{ fromJson(vars.SELF_HOSTED_RUNNER) }}
 
     steps:
       - name: Check pr title
@@ -20,7 +21,8 @@ jobs:
     if: github.head_ref != 'changeset-release/main'
 
     name: Changeset
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: ${{ fromJson(vars.SELF_HOSTED_RUNNER) }}
 
     steps:
       - name: Checkout branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,8 @@ concurrency:
 jobs:
   release:
     name: Changelog PR or Release
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: ${{ fromJson(vars.SELF_HOSTED_RUNNER) }}
 
     steps:
       - name: Checkout branch


### PR DESCRIPTION
## Summary
Replaces `ubuntu-latest` with self-hosted runner via `vars.SELF_HOSTED_RUNNER` org variable.

Jira: [CENGINE-6052](https://project44.atlassian.net/browse/CENGINE-6052)

Part of org-wide runner migration — all Priority 1 CI/CD and release pipelines.

## Test plan
- [ ] Confirm workflows trigger on the feature branch and pick up self-hosted runners
- [ ] No functional changes to build steps — runner label change only

[CENGINE-6052]: https://project44.atlassian.net/browse/CENGINE-6052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ